### PR TITLE
Maintenance tasks do not run after migration to PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -415,3 +415,6 @@ docs/.bundle
 # Database files
 database/postgres
 database/postgres-dev
+
+# Temp files
+temp

--- a/src/AliasVault.Admin/Main/Components/WorkerStatus/ServiceControl.razor
+++ b/src/AliasVault.Admin/Main/Components/WorkerStatus/ServiceControl.razor
@@ -5,10 +5,10 @@
 {
     <button @onclick="() => ServiceClick(service.Name)"
             class="@GetServiceButtonClasses(service) mx-3 inline-flex items-center justify-center rounded-xl px-8 py-2 text-white"
-            disabled="@(!IsHeartbeatValid(service.LastHeartbeat))"
-            title="@GetButtonTooltip(service.LastHeartbeat)">
+            disabled="@(!service.IsHeartBeatValid)"
+            title="@GetButtonTooltip(service)">
         <span>@service.DisplayName</span>
-        @if (service.IsPending)
+        @if (service.IsHeartBeatValid && service.CurrentStatus != service.DesiredStatus && !string.IsNullOrEmpty(service.DesiredStatus))
         {
             <svg class="animate-spin ml-2 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -54,9 +54,9 @@
     {
         public string Name { get; set; } = "";
         public string DisplayName { get; set; } = "";
-        public bool Status { get; set; }
-        public bool IsPending { get; set; }
-        public DateTime LastHeartbeat { get; set; }
+        public string CurrentStatus { get; set; } = "";
+        public string DesiredStatus { get; set; } = "";
+        public bool IsHeartBeatValid { get; set; }
     }
 
     private List<ServiceState> Services { get; set; } = [];
@@ -112,15 +112,23 @@
     {
         string buttonClass = "cursor-pointer ";
 
-        if (!IsHeartbeatValid(service.LastHeartbeat))
+        if (!service.IsHeartBeatValid)
         {
             buttonClass += "bg-gray-600";
         }
-        else if (service.Status)
+        else if (service.CurrentStatus == "Started" && (service.DesiredStatus == string.Empty || service.DesiredStatus == "Started"))
         {
             buttonClass += "bg-green-600";
         }
-        else
+        else if (service.CurrentStatus == "Stopping" || (service.DesiredStatus == "Stopped" && service.CurrentStatus != service.DesiredStatus))
+        {
+            buttonClass += "bg-red-500";
+        }
+        else if (service.CurrentStatus == "Starting" || (service.DesiredStatus == "Started" && service.CurrentStatus != service.DesiredStatus))
+        {
+            buttonClass += "bg-emerald-500";
+        }
+        else if (service.DesiredStatus == "Stopped" && (service.DesiredStatus == string.Empty || service.DesiredStatus == "Stopped"))
         {
             buttonClass += "bg-red-600";
         }
@@ -131,9 +139,22 @@
     /// <summary>
     /// Gets the tooltip text for a service button based on its last heartbeat.
     /// </summary>
-    private static string GetButtonTooltip(DateTime lastHeartbeat)
+    private static string GetButtonTooltip(ServiceState service)
     {
-        return IsHeartbeatValid(lastHeartbeat) ? "" : "Heartbeat offline";
+        if (!service.IsHeartBeatValid)
+        {
+            return "Heartbeat offline";
+        }
+
+        var statusMessages = new Dictionary<string, string>
+        {
+            { "Started", "Service is running" },
+            { "Starting", "Service is starting..." },
+            { "Stopped", "Service is stopped" },
+            { "Stopping", "Service is stopping..." }
+        };
+
+        return statusMessages.GetValueOrDefault(service.CurrentStatus, string.Empty);
     }
 
     /// <summary>
@@ -143,18 +164,25 @@
     {
         var service = Services.First(s => s.Name == serviceName);
 
-        if (!IsHeartbeatValid(service.LastHeartbeat))
+        if (!service.IsHeartBeatValid)
         {
             return;
         }
 
-        service.IsPending = true;
+        // If service not started and not starting, clicking should start it. Otherwise, stop it.
+        if (service.CurrentStatus == "Started" || service.DesiredStatus == "Started")
+        {
+            service.DesiredStatus = "Stopped";
+        }
+        else
+        {
+            service.DesiredStatus = "Started";
+        }
         StateHasChanged();
 
-        service.Status = !service.Status;
-        await UpdateServiceStatus(serviceName, service.Status);
+        await UpdateServiceStatus(serviceName, service.DesiredStatus);
+        service.CurrentStatus = service.DesiredStatus;
 
-        service.IsPending = false;
         StateHasChanged();
     }
 
@@ -163,7 +191,7 @@
     /// </summary>
     private async Task InitPage()
     {
-        if (InitInProgress || Services.Any(s => s.IsPending))
+        if (InitInProgress)
         {
             return;
         }
@@ -179,8 +207,9 @@
                 var entry = ServiceStatus.Find(x => x.ServiceName == service.Name);
                 if (entry != null)
                 {
-                    service.LastHeartbeat = entry.Heartbeat;
-                    service.Status = IsHeartbeatValid(service.LastHeartbeat) && entry.CurrentStatus == "Started";
+                    service.IsHeartBeatValid = IsHeartbeatValid(entry.Heartbeat);
+                    service.CurrentStatus = entry.CurrentStatus;
+                    service.DesiredStatus = entry.DesiredStatus;
                 }
             }
 
@@ -195,14 +224,13 @@
     /// <summary>
     /// Updates the status of a service.
     /// </summary>
-    private async Task<bool> UpdateServiceStatus(string serviceName, bool newStatus)
+    private async Task<bool> UpdateServiceStatus(string serviceName, string desiredStatus)
     {
         await using var dbContext = await DbContextFactory.CreateDbContextAsync();
         var entry = await dbContext.WorkerServiceStatuses.Where(x => x.ServiceName == serviceName).FirstOrDefaultAsync();
         if (entry != null)
         {
-            string newDesiredStatus = newStatus ? "Started" : "Stopped";
-            entry.DesiredStatus = newDesiredStatus;
+            entry.DesiredStatus = desiredStatus;
             await dbContext.SaveChangesAsync();
 
             var timeout = DateTime.UtcNow.AddSeconds(30);
@@ -215,7 +243,7 @@
 
                 await using var dbContextInner = await DbContextFactory.CreateDbContextAsync();
                 var check = await dbContextInner.WorkerServiceStatuses.Where(x => x.ServiceName == serviceName).FirstAsync();
-                if (check.CurrentStatus == newDesiredStatus)
+                if (check.CurrentStatus == entry.DesiredStatus)
                 {
                     return true;
                 }

--- a/src/AliasVault.Admin/Main/Pages/Dashboard/Index.razor
+++ b/src/AliasVault.Admin/Main/Pages/Dashboard/Index.razor
@@ -27,16 +27,22 @@
     private EmailStatisticsCard? _emailStatisticsCard;
 
     /// <inheritdoc />
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        // Check if 2FA is enabled. If not, show a one-time warning on the dashboard.
+        if (!UserService.User().TwoFactorEnabled)
+        {
+            GlobalNotificationService.AddWarningMessage("Two-factor authentication is not enabled. It is recommended to enable it in Account Settings for better security.", true);
+        }
+    }
+
+    /// <inheritdoc />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
-            // Check if 2FA is enabled. If not, show a one-time warning on the dashboard.
-            if (!UserService.User().TwoFactorEnabled)
-            {
-                GlobalNotificationService.AddWarningMessage("Two-factor authentication is not enabled. It is recommended to enable it in Account Settings for better security.", true);
-            }
-
             await RefreshData();
         }
     }

--- a/src/AliasVault.Admin/Main/Pages/Settings/Server.razor
+++ b/src/AliasVault.Admin/Main/Pages/Settings/Server.razor
@@ -162,7 +162,7 @@
         }
         catch (Exception ex)
         {
-            GlobalNotificationService.AddErrorMessage($"Failed to start maintenance tasks: {ex.Message}", true);
+            GlobalNotificationService.AddErrorMessage($"Failed to start maintenance tasks: {ex}", true);
         }
     }
 

--- a/src/AliasVault.Admin/Properties/launchSettings.json
+++ b/src/AliasVault.Admin/Properties/launchSettings.json
@@ -17,7 +17,7 @@
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development",
           "ADMIN_PASSWORD_HASH": "AQAAAAIAAYagAAAAEKWfKfa2gh9Z72vjAlnNP1xlME7FsunRznzyrfqFte40FToufRwa3kX8wwDwnEXZag==",
-          "ADMIN_PASSWORD_GENERATED": "2024-01-01T00:00:00Z",
+          "ADMIN_PASSWORD_GENERATED": "2030-01-01T00:00:00Z",
           "DATA_PROTECTION_CERT_PASS": "Development"
         }
       },

--- a/src/AliasVault.Admin/wwwroot/css/tailwind.css
+++ b/src/AliasVault.Admin/wwwroot/css/tailwind.css
@@ -670,6 +670,10 @@ video {
   margin-left: auto;
 }
 
+.mr-1 {
+  margin-right: 0.25rem;
+}
+
 .mr-14 {
   margin-right: 3.5rem;
 }
@@ -1148,6 +1152,11 @@ video {
   background-color: rgb(59 130 246 / var(--tw-bg-opacity));
 }
 
+.bg-emerald-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(16 185 129 / var(--tw-bg-opacity));
+}
+
 .bg-gray-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));
@@ -1496,10 +1505,6 @@ video {
 
 .font-semibold {
   font-weight: 600;
-}
-
-.uppercase {
-  text-transform: uppercase;
 }
 
 .leading-6 {

--- a/src/Shared/AliasVault.Shared/Models/Enums/TaskRunnerJobStatus.cs
+++ b/src/Shared/AliasVault.Shared/Models/Enums/TaskRunnerJobStatus.cs
@@ -28,6 +28,11 @@ public enum TaskRunnerJobStatus
     Finished = 2,
 
     /// <summary>
+    /// The job has been canceled because the task runner has been stopped.
+    /// </summary>
+    Canceled = 8,
+
+    /// <summary>
     /// The job has failed.
     /// </summary>
     Error = 9,

--- a/src/Tests/AliasVault.IntegrationTests/AbstractTestHostBuilder.cs
+++ b/src/Tests/AliasVault.IntegrationTests/AbstractTestHostBuilder.cs
@@ -1,0 +1,161 @@
+// -----------------------------------------------------------------------
+// <copyright file="AbstractTestHostBuilder.cs" company="lanedirt">
+// Copyright (c) lanedirt. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace AliasVault.IntegrationTests;
+
+using AliasServerDb;
+using AliasServerDb.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+
+/// <summary>
+/// Builder class for creating a test host for services in order to run integration tests against them. This class
+/// contains common logic such as creating a temporary database.
+/// </summary>
+public class AbstractTestHostBuilder : IAsyncDisposable
+{
+    /// <summary>
+    /// The DbContextFactory instance that is created for the test.
+    /// </summary>
+    private IAliasServerDbContextFactory _dbContextFactory = null!;
+
+    /// <summary>
+    /// The cached DbContext instance that can be used during the test.
+    /// </summary>
+    private AliasServerDbContext? _dbContext;
+
+    /// <summary>
+    /// The temporary database name for the test.
+    /// </summary>
+    private string? _tempDbName;
+
+    /// <summary>
+    /// Returns the DbContext instance for the test. This can be used to seed the database with test data.
+    /// </summary>
+    /// <returns>AliasServerDbContext instance.</returns>
+    public AliasServerDbContext GetDbContext()
+    {
+        if (_dbContext != null)
+        {
+            return _dbContext;
+        }
+
+        _dbContext = _dbContextFactory.CreateDbContext();
+        return _dbContext;
+    }
+
+    /// <summary>
+    /// Returns the DbContext instance for the test. This can be used to seed the database with test data.
+    /// </summary>
+    /// <returns>AliasServerDbContext instance.</returns>
+    public async Task<AliasServerDbContext> GetDbContextAsync()
+    {
+        return await _dbContextFactory.CreateDbContextAsync();
+    }
+
+    /// <summary>
+    /// Disposes of the test host and cleans up the temporary database.
+    /// </summary>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext != null)
+        {
+            await _dbContext.DisposeAsync();
+            _dbContext = null;
+        }
+
+        if (!string.IsNullOrEmpty(_tempDbName))
+        {
+            // Create a connection to 'postgres' database to drop the test database
+            using var conn =
+                new NpgsqlConnection(
+                    "Host=localhost;Port=5433;Database=postgres;Username=aliasvault;Password=password");
+            await conn.OpenAsync();
+
+            // First terminate existing connections
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = $"""
+                                   SELECT pg_terminate_backend(pid)
+                                   FROM pg_stat_activity
+                                   WHERE datname = '{_tempDbName}';
+                                   """;
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            // Then drop the database
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = $"""
+                                   DROP DATABASE IF EXISTS "{_tempDbName}";
+                                   """;
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    /// <summary>
+    /// Creates a new test host builder with test database connection already configured.
+    /// </summary>
+    /// <returns>IHost.</returns>
+    protected IHostBuilder CreateBuilder()
+    {
+        _tempDbName = $"aliasdb_test_{Guid.NewGuid()}";
+
+        // Create a connection to 'postgres' database to ensure the test database exists
+        AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+
+        using (var conn = new NpgsqlConnection("Host=localhost;Port=5433;Database=postgres;Username=aliasvault;Password=password"))
+        {
+            conn.Open();
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = $"""
+                                   CREATE DATABASE "{_tempDbName}";
+                                   """;
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        // Create a connection to the new test database
+        var dbConnection = new NpgsqlConnection($"Host=localhost;Port=5433;Database={_tempDbName};Username=aliasvault;Password=password");
+
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureServices((context, services) =>
+            {
+                // Override configuration
+                var configuration = new ConfigurationBuilder()
+                    .AddJsonFile("appsettings.json", optional: true)
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["DatabaseProvider"] = "postgresql",
+                        ["ConnectionStrings:AliasServerDbContext"] = dbConnection.ConnectionString,
+                    })
+                    .Build();
+
+                services.AddSingleton<IConfiguration>(configuration);
+                services.AddAliasVaultDatabaseConfiguration(configuration);
+
+                // Ensure the in-memory database is populated with tables
+                var serviceProvider = services.BuildServiceProvider();
+                using (var scope = serviceProvider.CreateScope())
+                {
+                    _dbContextFactory = scope.ServiceProvider.GetRequiredService<IAliasServerDbContextFactory>();
+                    var dbContext = _dbContextFactory.CreateDbContext();
+                    dbContext.Database.Migrate();
+                }
+            });
+
+        return builder;
+    }
+}

--- a/src/Tests/AliasVault.IntegrationTests/AbstractTestHostBuilder.cs
+++ b/src/Tests/AliasVault.IntegrationTests/AbstractTestHostBuilder.cs
@@ -7,8 +7,10 @@
 
 namespace AliasVault.IntegrationTests;
 
+using System.Reflection;
 using AliasServerDb;
 using AliasServerDb.Configuration;
+using AliasVault.Logging;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -145,6 +147,7 @@ public class AbstractTestHostBuilder : IAsyncDisposable
 
                 services.AddSingleton<IConfiguration>(configuration);
                 services.AddAliasVaultDatabaseConfiguration(configuration);
+                services.ConfigureLogging(configuration, Assembly.GetExecutingAssembly().GetName().Name!, "logs");
 
                 // Ensure the in-memory database is populated with tables
                 var serviceProvider = services.BuildServiceProvider();

--- a/src/Tests/AliasVault.IntegrationTests/SmtpServer/TestHostBuilder.cs
+++ b/src/Tests/AliasVault.IntegrationTests/SmtpServer/TestHostBuilder.cs
@@ -7,11 +7,13 @@
 
 namespace AliasVault.IntegrationTests.SmtpServer;
 
+using System.Data.Common;
 using AliasVault.SmtpService;
 using AliasVault.SmtpService.Handlers;
 using AliasVault.SmtpService.Workers;
 using global::SmtpServer;
 using global::SmtpServer.Storage;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -23,6 +25,38 @@ public class TestHostBuilder : AbstractTestHostBuilder
     /// <summary>
     /// Builds the SmtpService test host with a provided database connection.
     /// </summary>
+    /// <param name="dbConnection">The database connection to use for the test.</param>
+    /// <returns>IHost.</returns>
+    public IHost Build(DbConnection dbConnection)
+    {
+        // Get base builder with database connection already configured.
+        var builder = CreateBuilder();
+
+        // Add specific services for the TestExceptionWorker.
+        builder.ConfigureServices((context, services) =>
+        {
+            // Override database connection with provided connection.
+            services.Remove(services.First(x => x.ServiceType == typeof(IConfiguration)));
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["DatabaseProvider"] = "postgresql",
+                    ["ConnectionStrings:AliasServerDbContext"] = dbConnection.ConnectionString,
+                })
+                .Build();
+
+            services.AddSingleton<IConfiguration>(configuration);
+
+            ConfigureSmtpServices(services);
+        });
+
+        return builder.Build();
+    }
+
+    /// <summary>
+    /// Builds the SmtpService test host with a new database connection.
+    /// </summary>
     /// <returns>IHost.</returns>
     public IHost Build()
     {
@@ -32,35 +66,44 @@ public class TestHostBuilder : AbstractTestHostBuilder
         // Add specific services for the TestExceptionWorker.
         builder.ConfigureServices((context, services) =>
         {
-            services.AddSingleton(new Config
-            {
-                AllowedToDomains = new List<string> { "example.tld" },
-                SmtpTlsEnabled = "false",
-            });
-
-            services.AddTransient<IMessageStore, DatabaseMessageStore>();
-            services.AddSingleton<SmtpServer>(
-                provider =>
-                {
-                    var options = new SmtpServerOptionsBuilder()
-                        .ServerName("aliasvault");
-
-                    // Note: port 25 doesn't work in GitHub actions so we use these instead for the integration tests:
-                    // - 2525 for the SMTP server
-                    // - 5870 for the submission server
-                    options.Endpoint(serverBuilder =>
-                            serverBuilder
-                                .Port(2525, false))
-                        .Endpoint(serverBuilder =>
-                            serverBuilder
-                                .Port(5870, false));
-
-                    return new SmtpServer(options.Build(), provider.GetRequiredService<IServiceProvider>());
-                });
-
-            services.AddHostedService<SmtpServerWorker>();
+            ConfigureSmtpServices(services);
         });
 
         return builder.Build();
+    }
+
+    /// <summary>
+    /// Configures the SMTP services for the test host.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    private void ConfigureSmtpServices(IServiceCollection services)
+    {
+        services.AddSingleton(new Config
+        {
+            AllowedToDomains = new List<string> { "example.tld" },
+            SmtpTlsEnabled = "false",
+        });
+
+        services.AddTransient<IMessageStore, DatabaseMessageStore>();
+        services.AddSingleton<SmtpServer>(
+            provider =>
+            {
+                var options = new SmtpServerOptionsBuilder()
+                    .ServerName("aliasvault");
+
+                // Note: port 25 doesn't work in GitHub actions so we use these instead for the integration tests:
+                // - 2525 for the SMTP server
+                // - 5870 for the submission server
+                options.Endpoint(serverBuilder =>
+                        serverBuilder
+                            .Port(2525, false))
+                    .Endpoint(serverBuilder =>
+                        serverBuilder
+                            .Port(5870, false));
+
+                return new SmtpServer(options.Build(), provider.GetRequiredService<IServiceProvider>());
+            });
+
+        services.AddHostedService<SmtpServerWorker>();
     }
 }

--- a/src/Tests/AliasVault.IntegrationTests/SmtpServer/TestHostBuilder.cs
+++ b/src/Tests/AliasVault.IntegrationTests/SmtpServer/TestHostBuilder.cs
@@ -7,185 +7,60 @@
 
 namespace AliasVault.IntegrationTests.SmtpServer;
 
-using System.Data.Common;
-using AliasServerDb;
-using AliasServerDb.Configuration;
 using AliasVault.SmtpService;
 using AliasVault.SmtpService.Handlers;
 using AliasVault.SmtpService.Workers;
 using global::SmtpServer;
 using global::SmtpServer.Storage;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Npgsql;
 
 /// <summary>
 /// Builder class for creating a test host for the SmtpServiceWorker in order to run integration tests against it.
 /// </summary>
-public class TestHostBuilder : IAsyncDisposable
+public class TestHostBuilder : AbstractTestHostBuilder
 {
     /// <summary>
-    /// The DbContextFactory instance that is created for the test.
-    /// </summary>
-    private IAliasServerDbContextFactory _dbContextFactory = null!;
-
-    /// <summary>
-    /// The cached DbContext instance that can be used during the test.
-    /// </summary>
-    private AliasServerDbContext? _dbContext;
-
-    /// <summary>
-    /// The temporary database name for the test.
-    /// </summary>
-    private string? _tempDbName;
-
-    /// <summary>
-    /// Returns the DbContext instance for the test. This can be used to seed the database with test data.
-    /// </summary>
-    /// <returns>AliasServerDbContext instance.</returns>
-    public AliasServerDbContext GetDbContext()
-    {
-        if (_dbContext != null)
-        {
-            return _dbContext;
-        }
-
-        _dbContext = _dbContextFactory.CreateDbContext();
-        return _dbContext;
-    }
-
-    /// <summary>
-    /// Builds the SmtpService test host.
+    /// Builds the SmtpService test host with a provided database connection.
     /// </summary>
     /// <returns>IHost.</returns>
     public IHost Build()
     {
-        _tempDbName = $"aliasdb_test_{Guid.NewGuid()}";
+        // Get base builder with database connection already configured.
+        var builder = CreateBuilder();
 
-        // Create a connection to 'postgres' database to ensure the test database exists
-        using (var conn = new NpgsqlConnection("Host=localhost;Port=5433;Database=postgres;Username=aliasvault;Password=password"))
+        // Add specific services for the TestExceptionWorker.
+        builder.ConfigureServices((context, services) =>
         {
-            conn.Open();
-            using (var cmd = conn.CreateCommand())
+            services.AddSingleton(new Config
             {
-                cmd.CommandText = $"""
-                    CREATE DATABASE "{_tempDbName}";
-                    """;
-                cmd.ExecuteNonQuery();
-            }
-        }
-
-        // Create a connection to the new test database
-        var dbConnection = new NpgsqlConnection($"Host=localhost;Port=5433;Database={_tempDbName};Username=aliasvault;Password=password");
-
-        return Build(dbConnection);
-    }
-
-    /// <summary>
-    /// Builds the SmtpService test host with a provided database connection.
-    /// </summary>
-    /// <param name="dbConnection">The database connection to use for the test.</param>
-    /// <returns>IHost.</returns>
-    public IHost Build(DbConnection dbConnection)
-    {
-        var builder = Host.CreateDefaultBuilder()
-            .ConfigureServices((context, services) =>
-            {
-                // Override configuration
-                var configuration = new ConfigurationBuilder()
-                    .AddJsonFile("appsettings.json", optional: true)
-                    .AddInMemoryCollection(new Dictionary<string, string?>
-                    {
-                        ["DatabaseProvider"] = "postgresql",
-                        ["ConnectionStrings:AliasServerDbContext"] = dbConnection.ConnectionString,
-                    })
-                    .Build();
-
-                services.AddSingleton<IConfiguration>(configuration);
-
-                services.AddSingleton(new Config
-                {
-                    AllowedToDomains = new List<string> { "example.tld" },
-                    SmtpTlsEnabled = "false",
-                });
-
-                services.AddTransient<IMessageStore, DatabaseMessageStore>();
-                services.AddSingleton<SmtpServer>(
-                    provider =>
-                    {
-                        var options = new SmtpServerOptionsBuilder()
-                            .ServerName("aliasvault");
-
-                        // Note: port 25 doesn't work in GitHub actions so we use these instead for the integration tests:
-                        // - 2525 for the SMTP server
-                        // - 5870 for the submission server
-                        options.Endpoint(serverBuilder =>
-                                serverBuilder
-                                    .Port(2525, false))
-                            .Endpoint(serverBuilder =>
-                                serverBuilder
-                                    .Port(5870, false));
-
-                        return new SmtpServer(options.Build(), provider.GetRequiredService<IServiceProvider>());
-                    });
-
-                services.AddAliasVaultDatabaseConfiguration(configuration);
-                services.AddHostedService<SmtpServerWorker>();
-
-                // Ensure the in-memory database is populated with tables
-                var serviceProvider = services.BuildServiceProvider();
-                using (var scope = serviceProvider.CreateScope())
-                {
-                    _dbContextFactory = scope.ServiceProvider.GetRequiredService<IAliasServerDbContextFactory>();
-                    var dbContext = _dbContextFactory.CreateDbContext();
-                    dbContext.Database.Migrate();
-                }
+                AllowedToDomains = new List<string> { "example.tld" },
+                SmtpTlsEnabled = "false",
             });
 
+            services.AddTransient<IMessageStore, DatabaseMessageStore>();
+            services.AddSingleton<SmtpServer>(
+                provider =>
+                {
+                    var options = new SmtpServerOptionsBuilder()
+                        .ServerName("aliasvault");
+
+                    // Note: port 25 doesn't work in GitHub actions so we use these instead for the integration tests:
+                    // - 2525 for the SMTP server
+                    // - 5870 for the submission server
+                    options.Endpoint(serverBuilder =>
+                            serverBuilder
+                                .Port(2525, false))
+                        .Endpoint(serverBuilder =>
+                            serverBuilder
+                                .Port(5870, false));
+
+                    return new SmtpServer(options.Build(), provider.GetRequiredService<IServiceProvider>());
+                });
+
+            services.AddHostedService<SmtpServerWorker>();
+        });
+
         return builder.Build();
-    }
-
-    /// <summary>
-    /// Disposes of the test host and cleans up the temporary database.
-    /// </summary>
-    /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
-    public async ValueTask DisposeAsync()
-    {
-        if (_dbContext != null)
-        {
-            await _dbContext.DisposeAsync();
-            _dbContext = null;
-        }
-
-        if (!string.IsNullOrEmpty(_tempDbName))
-        {
-            // Create a connection to 'postgres' database to drop the test database
-            using var conn = new NpgsqlConnection("Host=localhost;Port=5433;Database=postgres;Username=aliasvault;Password=password");
-            await conn.OpenAsync();
-
-            // First terminate existing connections
-            using (var cmd = conn.CreateCommand())
-            {
-                cmd.CommandText = $"""
-                    SELECT pg_terminate_backend(pid)
-                    FROM pg_stat_activity
-                    WHERE datname = '{_tempDbName}';
-                    """;
-                await cmd.ExecuteNonQueryAsync();
-            }
-
-            // Then drop the database
-            using (var cmd = conn.CreateCommand())
-            {
-                cmd.CommandText = $"""
-                    DROP DATABASE IF EXISTS "{_tempDbName}";
-                    """;
-                await cmd.ExecuteNonQueryAsync();
-            }
-
-            GC.SuppressFinalize(this);
-        }
     }
 }

--- a/src/Tests/AliasVault.IntegrationTests/SmtpServer/TestHostBuilder.cs
+++ b/src/Tests/AliasVault.IntegrationTests/SmtpServer/TestHostBuilder.cs
@@ -76,7 +76,7 @@ public class TestHostBuilder : AbstractTestHostBuilder
     /// Configures the SMTP services for the test host.
     /// </summary>
     /// <param name="services">The service collection to configure.</param>
-    private void ConfigureSmtpServices(IServiceCollection services)
+    private static void ConfigureSmtpServices(IServiceCollection services)
     {
         services.AddSingleton(new Config
         {

--- a/src/Tests/AliasVault.IntegrationTests/StatusHostedService/StatusHostedServiceTests.cs
+++ b/src/Tests/AliasVault.IntegrationTests/StatusHostedService/StatusHostedServiceTests.cs
@@ -55,13 +55,13 @@ public class StatusHostedServiceTests
     [Test]
     public async Task LogsExceptionFromWrappedService()
     {
-        // Start the service which will trigger the TestExceptionWorker to throw
+        // Start the service which will trigger the TestExceptionWorker to throw an exception.
         await _testHost.StartAsync();
 
-        // Give it a moment to process
-        await Task.Delay(5000);
+        // Give it a moment to process.
+        await Task.Delay(3000);
 
-        // Check the logs for the expected error
+        // Check the logs for the expected error.
         await using var dbContext = _testHostBuilder.GetDbContext();
         var errorLog = await dbContext.Logs
             .OrderByDescending(l => l.TimeStamp)

--- a/src/Tests/AliasVault.IntegrationTests/StatusHostedService/StatusHostedServiceTests.cs
+++ b/src/Tests/AliasVault.IntegrationTests/StatusHostedService/StatusHostedServiceTests.cs
@@ -1,0 +1,73 @@
+//-----------------------------------------------------------------------
+// <copyright file="StatusHostedServiceTests.cs" company="lanedirt">
+// Copyright (c) lanedirt. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace AliasVault.IntegrationTests.StatusHostedService;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Integration tests for StatusHostedService wrapper.
+/// </summary>
+[TestFixture]
+public class StatusHostedServiceTests
+{
+    /// <summary>
+    /// The test host instance.
+    /// </summary>
+    private IHost _testHost;
+
+    /// <summary>
+    /// The test host builder instance.
+    /// </summary>
+    private TestHostBuilder _testHostBuilder;
+
+    /// <summary>
+    /// Setup logic for every test.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        _testHostBuilder = new TestHostBuilder();
+        _testHost = _testHostBuilder.Build();
+    }
+
+    /// <summary>
+    /// Tear down logic for every test.
+    /// </summary>
+    /// <returns>Task.</returns>
+    [TearDown]
+    public async Task TearDown()
+    {
+        await _testHost.StopAsync();
+        _testHost.Dispose();
+        await _testHostBuilder.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Tests that the StatusHostedService properly logs errors from the wrapped service.
+    /// </summary>
+    /// <returns>Task.</returns>
+    [Test]
+    public async Task LogsExceptionFromWrappedService()
+    {
+        // Start the service which will trigger the TestExceptionWorker to throw
+        await _testHost.StartAsync();
+
+        // Give it a moment to process
+        await Task.Delay(5000);
+
+        // Check the logs for the expected error
+        await using var dbContext = _testHostBuilder.GetDbContext();
+        var errorLog = await dbContext.Logs
+            .OrderByDescending(l => l.TimeStamp)
+            .FirstOrDefaultAsync(l => l.Level == "Error" && l.Exception.Contains("Test exception"));
+
+        Assert.That(errorLog, Is.Not.Null, "Expected error log from TestExceptionWorker was not found");
+        Assert.That(errorLog.Message, Does.Contain("An error occurred in StatusHostedService"), "Error log does not contain expected message from StatusHostedService");
+    }
+}

--- a/src/Tests/AliasVault.IntegrationTests/StatusHostedService/TestExceptionWorker.cs
+++ b/src/Tests/AliasVault.IntegrationTests/StatusHostedService/TestExceptionWorker.cs
@@ -1,0 +1,23 @@
+//-----------------------------------------------------------------------
+// <copyright file="TestExceptionWorker.cs" company="lanedirt">
+// Copyright (c) lanedirt. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace AliasVault.IntegrationTests.StatusHostedService;
+
+using Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// A simple worker that throws an exception during task execution. This is used for testing purposes.
+/// </summary>
+public class TestExceptionWorker() : BackgroundService
+{
+    /// <inheritdoc/>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Task.Delay(TimeSpan.FromMilliseconds(100), stoppingToken);
+        throw new Exception("Test exception");
+    }
+}

--- a/src/Tests/AliasVault.IntegrationTests/StatusHostedService/TestHostBuilder.cs
+++ b/src/Tests/AliasVault.IntegrationTests/StatusHostedService/TestHostBuilder.cs
@@ -4,19 +4,12 @@
 // Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
 // </copyright>
 // -----------------------------------------------------------------------
-
 namespace AliasVault.IntegrationTests.StatusHostedService;
 
-using System.Data.Common;
 using System.Reflection;
 using AliasServerDb;
-using AliasServerDb.Configuration;
 using AliasVault.WorkerStatus.ServiceExtensions;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Npgsql;
 
 /// <summary>
 /// Builder class for creating a test host for the StatusHostedService wrapper in order to run integration tests

--- a/src/Tests/AliasVault.IntegrationTests/StatusHostedService/TestHostBuilder.cs
+++ b/src/Tests/AliasVault.IntegrationTests/StatusHostedService/TestHostBuilder.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// <copyright file="TestHostBuilder.cs" company="lanedirt">
+// Copyright (c) lanedirt. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace AliasVault.IntegrationTests.StatusHostedService;
+
+using System.Data.Common;
+using System.Reflection;
+using AliasServerDb;
+using AliasServerDb.Configuration;
+using AliasVault.WorkerStatus.ServiceExtensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+
+/// <summary>
+/// Builder class for creating a test host for the StatusHostedService wrapper in order to run integration tests
+/// against it. This primarily tests basic functionality of the hosted service such as starting, stopping and error
+/// handling.
+///
+/// The StatusHostedService is a wrapper around the HostedService class that provides additional functionality for
+/// managing the status of the hosted service. This includes being able to start and stop the services from the
+/// AliasVault admin panel.
+/// </summary>
+public class TestHostBuilder : AbstractTestHostBuilder
+{
+    /// <summary>
+    /// Builds the test host for the TestExceptionWorker.
+    /// </summary>
+    /// <returns>IHost.</returns>
+    public IHost Build()
+    {
+        // Get base builder with database connection already configured.
+        var builder = CreateBuilder();
+
+        // Add specific services for the TestExceptionWorker.
+        builder.ConfigureServices((context, services) =>
+        {
+            services.AddStatusHostedService<TestExceptionWorker, AliasServerDbContext>(Assembly.GetExecutingAssembly().GetName().Name!);
+        });
+
+        return builder.Build();
+    }
+}

--- a/src/Tests/AliasVault.IntegrationTests/TaskRunner/TaskRunnerTests.cs
+++ b/src/Tests/AliasVault.IntegrationTests/TaskRunner/TaskRunnerTests.cs
@@ -77,7 +77,7 @@ public class TaskRunnerTests
 
         // Assert
         await using var dbContext = await _testHostBuilder.GetDbContextAsync();
-        var generalLogs = await dbContext.Logs.ToListAsync();
+        var generalLogs = await dbContext.Logs.Where(x => x.Application == "TestApp").ToListAsync();
         Assert.That(generalLogs, Has.Count.EqualTo(50), "Only recent general logs should remain");
     }
 

--- a/src/Tests/AliasVault.IntegrationTests/TaskRunner/TestHostBuilder.cs
+++ b/src/Tests/AliasVault.IntegrationTests/TaskRunner/TestHostBuilder.cs
@@ -7,149 +7,41 @@
 
 namespace AliasVault.IntegrationTests.TaskRunner;
 
-using AliasServerDb;
-using AliasServerDb.Configuration;
 using AliasVault.Shared.Server.Services;
 using AliasVault.TaskRunner.Tasks;
 using AliasVault.TaskRunner.Workers;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Npgsql;
 
 /// <summary>
 /// Builder class for creating a test host for the TaskRunner in order to run integration tests against it.
 /// </summary>
-public class TestHostBuilder : IAsyncDisposable
+public class TestHostBuilder : AbstractTestHostBuilder
 {
-    /// <summary>
-    /// The DbContextFactory instance that is created for the test.
-    /// </summary>
-    private IAliasServerDbContextFactory _dbContextFactory = null!;
-
-    /// <summary>
-    /// The cached DbContext instance that can be used during the test.
-    /// </summary>
-    private AliasServerDbContext? _dbContext;
-
-    /// <summary>
-    /// The temporary database name for the test.
-    /// </summary>
-    private string? _tempDbName;
-
-    /// <summary>
-    /// Returns the DbContext instance for the test. This can be used to seed the database with test data.
-    /// </summary>
-    /// <returns>AliasServerDbContext instance.</returns>
-    public async Task<AliasServerDbContext> GetDbContextAsync()
-    {
-        return await _dbContextFactory.CreateDbContextAsync();
-    }
-
     /// <summary>
     /// Builds the TaskRunner test host.
     /// </summary>
     /// <returns>IHost.</returns>
     public IHost Build()
     {
-        // Create a temporary database for the test
-        _tempDbName = $"aliasdb_test_{Guid.NewGuid()}";
+        // Get base builder with database connection already configured.
+        var builder = CreateBuilder();
 
-        // Create a connection to 'postgres' database to create the test database
-        using (var conn = new NpgsqlConnection("Host=localhost;Port=5433;Database=postgres;Username=aliasvault;Password=password"))
+        // Add specific services for the TestExceptionWorker.
+        builder.ConfigureServices((context, services) =>
         {
-            conn.Open();
-            using (var cmd = conn.CreateCommand())
-            {
-                cmd.CommandText = $"""
-                    CREATE DATABASE "{_tempDbName}";
-                    """;
-                cmd.ExecuteNonQuery();
-            }
-        }
+            // Add server settings service
+            services.AddSingleton<ServerSettingsService>();
 
-        // Create the connection to the new test database
-        var dbConnection = new NpgsqlConnection($"Host=localhost;Port=5433;Database={_tempDbName};Username=aliasvault;Password=password");
-        var builder = Host.CreateDefaultBuilder()
-            .ConfigureServices((context, services) =>
-            {
-                // Override configuration
-                var configuration = new ConfigurationBuilder()
-                    .AddJsonFile("appsettings.json", optional: true)
-                    .AddInMemoryCollection(new Dictionary<string, string?>
-                    {
-                        ["DatabaseProvider"] = "postgresql",
-                        ["ConnectionStrings:AliasServerDbContext"] = dbConnection.ConnectionString,
-                    })
-                    .Build();
-                services.AddSingleton<IConfiguration>(configuration);
+            // Add maintenance tasks
+            services.AddTransient<IMaintenanceTask, LogCleanupTask>();
+            services.AddTransient<IMaintenanceTask, EmailCleanupTask>();
+            services.AddTransient<IMaintenanceTask, EmailQuotaCleanupTask>();
 
-                // Add server settings service
-                services.AddSingleton<ServerSettingsService>();
-
-                // Add maintenance tasks
-                services.AddTransient<IMaintenanceTask, LogCleanupTask>();
-                services.AddTransient<IMaintenanceTask, EmailCleanupTask>();
-                services.AddTransient<IMaintenanceTask, EmailQuotaCleanupTask>();
-
-                services.AddAliasVaultDatabaseConfiguration(configuration);
-
-                // Add the TaskRunner worker
-                services.AddHostedService<TaskRunnerWorker>();
-
-                // Ensure the database is populated with tables
-                var serviceProvider = services.BuildServiceProvider();
-                using (var scope = serviceProvider.CreateScope())
-                {
-                    _dbContextFactory = scope.ServiceProvider.GetRequiredService<IAliasServerDbContextFactory>();
-                    var dbContext = _dbContextFactory.CreateDbContext();
-                    dbContext.Database.Migrate();
-                }
-            });
+            // Add the TaskRunner worker
+            services.AddHostedService<TaskRunnerWorker>();
+        });
 
         return builder.Build();
-    }
-
-    /// <summary>
-    /// Disposes of the test host and cleans up the temporary database.
-    /// </summary>
-    /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
-    public async ValueTask DisposeAsync()
-    {
-        if (_dbContext != null)
-        {
-            await _dbContext.DisposeAsync();
-            _dbContext = null;
-        }
-
-        if (!string.IsNullOrEmpty(_tempDbName))
-        {
-            // Create a connection to 'postgres' database to drop the test database
-            using var conn = new NpgsqlConnection("Host=localhost;Port=5433;Database=postgres;Username=aliasvault;Password=password");
-            await conn.OpenAsync();
-
-            // First terminate existing connections
-            using (var cmd = conn.CreateCommand())
-            {
-                cmd.CommandText = $"""
-                    SELECT pg_terminate_backend(pid)
-                    FROM pg_stat_activity
-                    WHERE datname = '{_tempDbName}';
-                    """;
-                await cmd.ExecuteNonQueryAsync();
-            }
-
-            // Then drop the database
-            using (var cmd = conn.CreateCommand())
-            {
-                cmd.CommandText = $"""
-                    DROP DATABASE IF EXISTS "{_tempDbName}";
-                    """;
-                await cmd.ExecuteNonQueryAsync();
-            }
-        }
-
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/Utilities/AliasVault.InstallCli/Program.cs
+++ b/src/Utilities/AliasVault.InstallCli/Program.cs
@@ -147,7 +147,7 @@ public static partial class Program
             await MigrateTable(sqliteContext.AliasVaultRoles, pgContext.AliasVaultRoles, pgContext, "AliasVaultRoles");
             await MigrateTable(sqliteContext.AliasVaultUsers, pgContext.AliasVaultUsers, pgContext, "AliasVaultUsers");
             await MigrateTable(sqliteContext.ServerSettings, pgContext.ServerSettings, pgContext, "ServerSettings");
-            await MigrateTable(sqliteContext.TaskRunnerJobs, pgContext.TaskRunnerJobs, pgContext, "TaskRunnerJobs");
+            await MigrateTable(sqliteContext.TaskRunnerJobs, pgContext.TaskRunnerJobs, pgContext, "TaskRunnerJobs", true);
             await MigrateTable(sqliteContext.DataProtectionKeys, pgContext.DataProtectionKeys, pgContext, "DataProtectionKeys", true);
             await MigrateTable(sqliteContext.Logs, pgContext.Logs, pgContext, "Logs", true);
             await MigrateTable(sqliteContext.AuthLogs, pgContext.AuthLogs, pgContext, "AuthLogs", true);

--- a/src/Utilities/AliasVault.WorkerStatus/ServiceExtensions/StatusHostedService.cs
+++ b/src/Utilities/AliasVault.WorkerStatus/ServiceExtensions/StatusHostedService.cs
@@ -53,14 +53,8 @@ public class StatusHostedService<T>(ILogger<StatusHostedService<T>> logger, Glob
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            // Add a second cancellationToken linked to the parent cancellation token.
-            // When the parent gets canceled this gets canceled as well. However, this one can also
-            // be canceled with a signal from the StatusWorker.
-            var workerCancellationTokenSource =
-                CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
-
             // Start the inner while loop with the second cancellationToken.
-            await ExecuteInnerAsync(workerCancellationTokenSource);
+            await ExecuteInnerAsync(stoppingToken);
 
             if (!stoppingToken.IsCancellationRequested)
             {
@@ -73,10 +67,15 @@ public class StatusHostedService<T>(ILogger<StatusHostedService<T>> logger, Glob
     /// <summary>
     /// Start the inner while loop which adds a second cancellationToken that is controlled by the StatusWorker.
     /// </summary>
-    /// <param name="workerCancellationTokenSource">Cancellation token.</param>
-    private async Task ExecuteInnerAsync(CancellationTokenSource workerCancellationTokenSource)
+    /// <param name="cancellationToken">Cancellation token.</param>
+    private async Task ExecuteInnerAsync(CancellationToken cancellationToken)
     {
         Task? workerTask = null;
+
+        // Add a second cancellationToken linked to the parent cancellation token.
+        // When the parent gets canceled this gets canceled as well. However, this one can also
+        // be canceled with a signal from the StatusWorker.
+        using var workerCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         while (!workerCancellationTokenSource.IsCancellationRequested)
         {
@@ -86,7 +85,6 @@ public class StatusHostedService<T>(ILogger<StatusHostedService<T>> logger, Glob
                 {
                     if (workerTask == null)
                     {
-                        globalServiceStatus.SetWorkerStatus(typeof(T).Name, true);
                         workerTask = Task.Run(() => WorkerLogic(workerCancellationTokenSource.Token), workerCancellationTokenSource.Token);
                     }
                 }
@@ -100,11 +98,15 @@ public class StatusHostedService<T>(ILogger<StatusHostedService<T>> logger, Glob
             else if (globalServiceStatus.CurrentStatus.ToStatusEnum() == Status.Stopped)
             {
                 // Do nothing, the worker is stopped.
+                globalServiceStatus.SetWorkerStatus(typeof(T).Name, false);
             }
 
             // Wait for a second before checking the status again.
             await Task.Delay(1000);
         }
+
+        // If we get here, cancel the worker task if it is still running.
+        await workerCancellationTokenSource.CancelAsync();
     }
 
     /// <summary>
@@ -142,36 +144,46 @@ public class StatusHostedService<T>(ILogger<StatusHostedService<T>> logger, Glob
             {
                 // Expected so we only log information.
                 logger.LogInformation(ex, "StatusHostedService<{ServiceType}> is stopping due to a cancellation request.", typeof(T).Name);
+                break;
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "An error occurred in StatusHostedService<{ServiceType}>", typeof(T).Name);
-                globalServiceStatus.SetWorkerStatus(typeof(T).Name, false);
+
+                // If service is explicitly stopped, break out of the loop immediately.
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
             }
             finally
             {
                 logger.LogWarning("StatusHostedService<{ServiceType}> stopped at: {Time}", typeof(T).Name, DateTimeOffset.Now);
-                globalServiceStatus.SetWorkerStatus(typeof(T).Name, false);
+
+                // Reset the delay when the service is explicitly stopped
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _restartDelayInMs = _restartMinDelayInMs;
+                }
             }
 
-            // If a fault occurred in the innerService, but it was not explicitly canceled,
-            // wait for a second before attempting to auto-restart the worker.
-            while (!cancellationToken.IsCancellationRequested)
+            if (cancellationToken.IsCancellationRequested)
             {
-                try
-                {
-                    await Task.Delay(_restartDelayInMs, cancellationToken);
-                    break; // Exit the loop if delay is successful
-                }
-                catch (TaskCanceledException)
-                {
-                    // If the delay is canceled, exit the loop
-                    break;
-                }
+                return;
             }
 
-            // Exponential backoff with a maximum delay
-            _restartDelayInMs = Math.Min(_restartDelayInMs * 2, _restartMaxDelayInMs);
+            try
+            {
+                // If an exception occurred, delay with exponential backoff with a maximum before retrying.
+                await Task.Delay(_restartDelayInMs, cancellationToken);
+                _restartDelayInMs = Math.Min(_restartDelayInMs * 2, _restartMaxDelayInMs);
+            }
+            catch (OperationCanceledException)
+            {
+                // Reset delay on cancellation
+                _restartDelayInMs = _restartMinDelayInMs;
+                return;
+            }
         }
     }
 }

--- a/src/Utilities/AliasVault.WorkerStatus/StatusWorker.cs
+++ b/src/Utilities/AliasVault.WorkerStatus/StatusWorker.cs
@@ -132,7 +132,7 @@ public class StatusWorker(ILogger<StatusWorker> logger, Func<IWorkerStatusDbCont
     /// <param name="stoppingToken">CancellationToken.</param>
     private async Task WaitForAllWorkersToStart(CancellationToken stoppingToken)
     {
-        while (!globalServiceStatus.AreAllWorkersRunning())
+        while (!globalServiceStatus.AreAllWorkersRunning() && !stoppingToken.IsCancellationRequested)
         {
             logger.LogInformation("Waiting for all workers to start...");
             await Task.Delay(1000, stoppingToken);
@@ -145,7 +145,7 @@ public class StatusWorker(ILogger<StatusWorker> logger, Func<IWorkerStatusDbCont
     /// <param name="stoppingToken">CancellationToken.</param>
     private async Task WaitForAllWorkersToStop(CancellationToken stoppingToken)
     {
-        while (!globalServiceStatus.AreAllWorkersStopped())
+        while (!globalServiceStatus.AreAllWorkersStopped() && !stoppingToken.IsCancellationRequested)
         {
             logger.LogInformation("Waiting for all workers to stop...");
             await Task.Delay(1000, stoppingToken);

--- a/src/Utilities/AliasVault.WorkerStatus/StatusWorker.cs
+++ b/src/Utilities/AliasVault.WorkerStatus/StatusWorker.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
-/// StatusWorker class for monitoring and controlling the status of the worker services.
+/// StatusWorker class for monitoring and controlling the status of individual worker services through a database.
 /// </summary>
 public class StatusWorker(ILogger<StatusWorker> logger, Func<IWorkerStatusDbContext> createDbContext, GlobalServiceStatus globalServiceStatus) : BackgroundService
 {
@@ -33,40 +33,18 @@ public class StatusWorker(ILogger<StatusWorker> logger, Func<IWorkerStatusDbCont
             try
             {
                 var statusEntry = await GetServiceStatus();
+
                 switch (statusEntry.CurrentStatus.ToStatusEnum())
                 {
                     case Status.Started:
                         // Ensure that all workers are running, if not, revert to "Starting" CurrentStatus.
-                        if (!globalServiceStatus.AreAllWorkersRunning())
-                        {
-                            await SetServiceStatus(statusEntry, Status.Starting.ToString());
-                            logger.LogInformation("Status was set to Started but not all workers are running (yet). Reverting to Starting.");
-                        }
-
+                        await HandleStartedStatus(statusEntry);
                         break;
                     case Status.Starting:
-                        if (globalServiceStatus.AreAllWorkersRunning())
-                        {
-                            await SetServiceStatus(statusEntry, Status.Started.ToString());
-                            logger.LogInformation("All workers started.");
-                        }
-                        else
-                        {
-                            logger.LogInformation("Waiting for all workers to start.");
-                        }
-
+                        await HandleStartingStatus(statusEntry);
                         break;
                     case Status.Stopping:
-                        if (globalServiceStatus.AreAllWorkersStopped())
-                        {
-                            await SetServiceStatus(statusEntry, Status.Stopped.ToString());
-                            logger.LogInformation("All workers stopped.");
-                        }
-                        else
-                        {
-                            logger.LogInformation("Waiting for all workers to stop.");
-                        }
-
+                        await HandleStoppingStatus(statusEntry);
                         break;
                     case Status.Stopped:
                         logger.LogInformation("Service is (soft) stopped.");
@@ -89,6 +67,56 @@ public class StatusWorker(ILogger<StatusWorker> logger, Func<IWorkerStatusDbCont
         // Mark the service as stopped.
         _dbContext = createDbContext();
         await SetServiceStatus(await GetServiceStatus(), "Stopped");
+    }
+
+    /// <summary>
+    /// Handles the Started status.
+    /// </summary>
+    /// <param name="statusEntry">The WorkerServiceStatus entry.</param>
+    /// <returns>Task.</returns>
+    private async Task HandleStartedStatus(WorkerServiceStatus statusEntry)
+    {
+        if (!globalServiceStatus.AreAllWorkersRunning())
+        {
+            await SetServiceStatus(statusEntry, Status.Starting.ToString());
+            logger.LogInformation("Status was set to Started but not all workers are running (yet). Reverting to Starting.");
+        }
+    }
+
+    /// <summary>
+    /// Handles the Starting status.
+    /// </summary>
+    /// <param name="statusEntry">The WorkerServiceStatus entry.</param>
+    /// <returns>Task.</returns>
+    private async Task HandleStartingStatus(WorkerServiceStatus statusEntry)
+    {
+        if (globalServiceStatus.AreAllWorkersRunning())
+        {
+            await SetServiceStatus(statusEntry, Status.Started.ToString());
+            logger.LogInformation("All workers started.");
+        }
+        else
+        {
+            logger.LogInformation("Waiting for all workers to start.");
+        }
+    }
+
+    /// <summary>
+    /// Handles the Stopping status.
+    /// </summary>
+    /// <param name="statusEntry">The WorkerServiceStatus entry.</param>
+    /// <returns>Task.</returns>
+    private async Task HandleStoppingStatus(WorkerServiceStatus statusEntry)
+    {
+        if (globalServiceStatus.AreAllWorkersStopped())
+        {
+            await SetServiceStatus(statusEntry, Status.Stopped.ToString());
+            logger.LogInformation("All workers stopped.");
+        }
+        else
+        {
+            logger.LogInformation("Waiting for all workers to stop.");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Issue was caused by Postgresql migration that did not properly reset auto increment id. This is now fixed.

Also fixes a bug in StatusHostedService mechanism that did not catch exceptions in inner backgroundservice. This is now also resolved.

For existing installations that have already ran the migrations this new version can potentially log a few errors, but eventually the TaskRunner will recover once the auto increment has been updated sufficiently and will then resume normal operation.