### PR TITLE
555 use relative url to access api instead of requiring hostname in env

### DIFF
--- a/src/AliasVault.Client/Program.cs
+++ b/src/AliasVault.Client/Program.cs
@@ -19,10 +19,6 @@ builder.Configuration.AddJsonFile($"appsettings.{builder.HostEnvironment.Environ
 
 var config = new Config();
 builder.Configuration.Bind(config);
-if (string.IsNullOrEmpty(config.ApiUrl))
-{
-    throw new KeyNotFoundException("ApiUrl is not set in the configuration.");
-}
 
 if (config.PrivateEmailDomains == null || config.PrivateEmailDomains.Count == 0)
 {
@@ -56,8 +52,9 @@ builder.Services.AddScoped(sp =>
     var httpClient = httpClientFactory.CreateClient("AliasVault.Api");
     var apiConfig = sp.GetRequiredService<Config>();
 
-    // Ensure the API URL ends with a forward slash
-    var baseUrl = apiConfig.ApiUrl.TrimEnd('/') + "/";
+    // If API URL is not set, use the current base URL and append "/api" which is the default for the Docker setup.
+    // If API URL override is set (used e.g. in dev), then ensure the API URL ends with a forward slash.
+    var baseUrl = string.IsNullOrEmpty(apiConfig.ApiUrl) ? builder.HostEnvironment.BaseAddress + "api/" : apiConfig.ApiUrl.TrimEnd('/') + "/";
     httpClient.BaseAddress = new Uri(baseUrl);
     return httpClient;
 });

--- a/src/AliasVault.Client/entrypoint.sh
+++ b/src/AliasVault.Client/entrypoint.sh
@@ -1,11 +1,9 @@
 #!/bin/sh
-# Set the default hostname for localhost debugging
-DEFAULT_HOSTNAME="localhost"
+# Set the default values
 DEFAULT_PRIVATE_EMAIL_DOMAINS="localmail.tld"
 DEFAULT_SUPPORT_EMAIL=""
 
-# Use the provided HOSTNAME environment variable if it exists, otherwise use the default
-HOSTNAME=${HOSTNAME:-$DEFAULT_HOSTNAME}
+# Use the provided environment variables if they exist, otherwise use defaults
 PRIVATE_EMAIL_DOMAINS=${PRIVATE_EMAIL_DOMAINS:-$DEFAULT_PRIVATE_EMAIL_DOMAINS}
 SUPPORT_EMAIL=${SUPPORT_EMAIL:-$DEFAULT_SUPPORT_EMAIL}
 
@@ -25,8 +23,9 @@ if [ ! -f /etc/nginx/ssl/nginx.crt ] || [ ! -f /etc/nginx/ssl/nginx.key ]; then
     chmod 600 /etc/nginx/ssl/nginx.key
 fi
 
-# Replace the default URL with the actual API URL constructed from hostname
-sed -i "s|http://localhost:5092|https://${HOSTNAME}/api|g" /usr/share/nginx/html/appsettings.json
+# Remove the default API URL as it's only used for local dev/debugging.
+# The app will use a relative URL instead (base url + "/api/" which is the default for the Docker setup).
+sed -i "s|\"ApiUrl\": \"http://localhost:5092\",||g" /usr/share/nginx/html/appsettings.json
 
 # Convert comma-separated list to JSON array
 json_array=$(echo $PRIVATE_EMAIL_DOMAINS | awk '{split($0,a,","); printf "["; for(i=1;i<=length(a);i++) {printf "\"%s\"", a[i]; if(i<length(a)) printf ","} printf "]"}')


### PR DESCRIPTION
## Description
Simplifies self-host installation process by only requiring to set `HOSTNAME` property during SSL certificate configuration and not before.

- [x] Feature enhancement

## Related Issues

Link to any issues that this PR addresses:
Fixes #555

## Checklist

- [ ] Code adheres to project standards and guidelines.
- [ ] Documentation has been updated where applicable.