### PR TITLE
Settings popup is cut off on client when switching to table view

### DIFF
--- a/src/AliasVault.Client/Main/Pages/Credentials/Home.razor
+++ b/src/AliasVault.Client/Main/Pages/Credentials/Home.razor
@@ -53,7 +53,7 @@ else
 {
     @if (DbService.Settings.CredentialsViewMode == "table")
     {
-        <div class="px-4">
+        <div class="px-4 min-h-[250px]">
             <CredentialsTable Credentials="Credentials" SortDirection="@(SortOrder == "desc" ? SortDirection.Descending : SortDirection.Ascending)" />
         </div>
     }

--- a/src/AliasVault.Client/wwwroot/css/tailwind.css
+++ b/src/AliasVault.Client/wwwroot/css/tailwind.css
@@ -936,6 +936,10 @@ video {
   max-height: 90vh;
 }
 
+.min-h-\[250px\] {
+  min-height: 250px;
+}
+
 .min-h-screen {
   min-height: 100vh;
 }
@@ -1400,10 +1404,6 @@ video {
   border-color: rgb(239 68 68 / var(--tw-border-opacity));
 }
 
-.border-transparent {
-  border-color: transparent;
-}
-
 .bg-amber-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(255 251 235 / var(--tw-bg-opacity));
@@ -1547,11 +1547,6 @@ video {
 .bg-yellow-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(254 252 232 / var(--tw-bg-opacity));
-}
-
-.bg-indigo-600 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(79 70 229 / var(--tw-bg-opacity));
 }
 
 .bg-opacity-50 {
@@ -2154,11 +2149,6 @@ video {
   background-color: rgb(153 27 27 / var(--tw-bg-opacity));
 }
 
-.hover\:bg-indigo-700:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(67 56 202 / var(--tw-bg-opacity));
-}
-
 .hover\:from-primary-600:hover {
   --tw-gradient-from: #d68338 var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(214 131 56 / 0) var(--tw-gradient-to-position);
@@ -2313,11 +2303,6 @@ video {
 .focus\:ring-red-500:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(239 68 68 / var(--tw-ring-opacity));
-}
-
-.focus\:ring-indigo-500:focus {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(99 102 241 / var(--tw-ring-opacity));
 }
 
 .focus\:ring-offset-2:focus {
@@ -2753,10 +2738,6 @@ video {
 .dark\:focus\:ring-red-900:focus:is(.dark *) {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(127 29 29 / var(--tw-ring-opacity));
-}
-
-.dark\:focus\:ring-offset-gray-800:focus:is(.dark *) {
-  --tw-ring-offset-color: #1f2937;
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
## Description
When credentials are shown in table view and there are only a few (2-3) credentials, the component height is too little which cuts off the setting popup when open. Adding a minimum height to the table component fixes this.

- [x] Bug fix

## Related Issues
Fixes #656

## Checklist
- [x] Code adheres to project standards and guidelines.
- [x] Documentation has been updated where applicable.
