### PR TITLE
Add missing translations for mobile app

### DIFF
--- a/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/vaultstore/keystoreprovider/AndroidKeystoreProvider.kt
+++ b/apps/mobile-app/android/app/src/main/java/net/aliasvault/app/vaultstore/keystoreprovider/AndroidKeystoreProvider.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.fragment.app.FragmentActivity
+import net.aliasvault.app.R
 import java.io.File
 import java.nio.ByteBuffer
 import java.security.KeyStore
@@ -117,10 +118,8 @@ class AndroidKeystoreProvider(
 
                 // Create BiometricPrompt
                 val promptInfo = BiometricPrompt.PromptInfo.Builder()
-                    .setTitle("Store Encryption Key")
-                    .setSubtitle(
-                        "Authenticate to securely store your encryption key in the Android Keystore. This enables secure access to your vault.",
-                    )
+                    .setTitle(context.getString(R.string.biometric_store_key_title))
+                    .setSubtitle(context.getString(R.string.biometric_store_key_subtitle))
                     .setAllowedAuthenticators(
                         BiometricManager.Authenticators.BIOMETRIC_STRONG or
                             BiometricManager.Authenticators.DEVICE_CREDENTIAL,
@@ -233,8 +232,8 @@ class AndroidKeystoreProvider(
 
                 // Create BiometricPrompt
                 val promptInfo = BiometricPrompt.PromptInfo.Builder()
-                    .setTitle("Unlock Vault")
-                    .setSubtitle("Authenticate to access your vault")
+                    .setTitle(context.getString(R.string.biometric_unlock_vault_title))
+                    .setSubtitle(context.getString(R.string.biometric_unlock_vault_subtitle))
                     .setAllowedAuthenticators(
                         BiometricManager.Authenticators.BIOMETRIC_STRONG or
                             BiometricManager.Authenticators.DEVICE_CREDENTIAL,

--- a/apps/mobile-app/android/app/src/main/res/values/strings.xml
+++ b/apps/mobile-app/android/app/src/main/res/values/strings.xml
@@ -5,10 +5,16 @@
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
   <string name="autofill_service_description" translatable="true">AliasVault AutoFill</string>
   <string name="aliasvault_icon">AliasVault icon</string>
-  
+
   <!-- AutofillService strings -->
   <string name="autofill_failed_to_retrieve">Failed to retrieve, open app</string>
   <string name="autofill_no_match_found">No match found, create new?</string>
   <string name="autofill_open_app">Open app</string>
   <string name="autofill_vault_locked">Vault locked</string>
+
+  <!-- Biometric prompts -->
+  <string name="biometric_store_key_title">Store Encryption Key</string>
+  <string name="biometric_store_key_subtitle">Authenticate to securely store your encryption key in the Android Keystore. This enables secure access to your vault.</string>
+  <string name="biometric_unlock_vault_title">Unlock Vault</string>
+  <string name="biometric_unlock_vault_subtitle">Authenticate to access your vault</string>
 </resources>

--- a/apps/mobile-app/app/(tabs)/credentials/index.tsx
+++ b/apps/mobile-app/app/(tabs)/credentials/index.tsx
@@ -172,7 +172,7 @@ export default function CredentialsScreen() : React.ReactNode {
           setIsLoadingCredentials(false);
 
           // Show modal with error message
-          Alert.alert('Error', error);
+          Alert.alert(t('credentials.errors.generic'), error);
 
           // Logout user
           await webApi.logout(error);

--- a/apps/mobile-app/app/(tabs)/emails/_layout.tsx
+++ b/apps/mobile-app/app/(tabs)/emails/_layout.tsx
@@ -22,7 +22,7 @@ export default function EmailsLayout(): React.ReactNode {
            * On iOS, we don't show the header as a custom collapsible header is used.
            * @returns {React.ReactNode} The header component
            */
-          headerTitle: (): React.ReactNode => Platform.OS === 'android' ? <AndroidHeader title="Emails" /> : <Text>Emails</Text>,
+          headerTitle: (): React.ReactNode => Platform.OS === 'android' ? <AndroidHeader title={t('emails.title')} /> : <Text>{t('emails.title')}</Text>,
           ...defaultHeaderOptions,
         }}
       />

--- a/apps/mobile-app/app/(tabs)/settings/android-autofill.tsx
+++ b/apps/mobile-app/app/(tabs)/settings/android-autofill.tsx
@@ -1,5 +1,6 @@
 import { router } from 'expo-router';
 import { StyleSheet, View, TouchableOpacity, Linking } from 'react-native';
+import { useTranslation } from 'react-i18next';
 
 import { useColors } from '@/hooks/useColorScheme';
 
@@ -14,6 +15,7 @@ import NativeVaultManager from '@/specs/NativeVaultManager';
  */
 export default function AndroidAutofillScreen() : React.ReactNode {
   const colors = useColors();
+  const { t } = useTranslation();
   const { markAutofillConfigured, shouldShowAutofillReminder } = useAuth();
 
   /**
@@ -123,25 +125,25 @@ export default function AndroidAutofillScreen() : React.ReactNode {
     <ThemedContainer>
       <ThemedScrollView>
         <View style={styles.warningContainer}>
-          <ThemedText style={styles.warningTitle}>⚠️ Experimental Feature</ThemedText>
+          <ThemedText style={styles.warningTitle}>{t('settings.androidAutofillSettings.warningTitle')}</ThemedText>
           <ThemedText style={styles.warningDescription}>
-            Autofill support for Android is currently in an experimental state.{' '}
+            {t('settings.androidAutofillSettings.warningDescription')}{' '}
             <ThemedText style={styles.warningLink} onPress={handleOpenDocs}>
-              Read more about it here
+              {t('settings.androidAutofillSettings.warningLink')}
             </ThemedText>
           </ThemedText>
         </View>
 
         <View>
           <ThemedText style={styles.headerText}>
-            You can configure AliasVault to provide native password autofill functionality in Android. Follow the instructions below to enable it.
+            {t('settings.androidAutofillSettings.headerText')}
           </ThemedText>
         </View>
 
         <View style={styles.instructionContainer}>
-          <ThemedText style={styles.instructionTitle}>How to enable:</ThemedText>
+          <ThemedText style={styles.instructionTitle}>{t('settings.androidAutofillSettings.howToEnable')}</ThemedText>
           <ThemedText style={styles.instructionStep}>
-            1. Open Android Settings via the button below, and change the &quot;autofill preferred service&quot; to &quot;AliasVault&quot;
+            {t('settings.androidAutofillSettings.step1')}
           </ThemedText>
           <View style={styles.buttonContainer}>
             <TouchableOpacity
@@ -149,15 +151,15 @@ export default function AndroidAutofillScreen() : React.ReactNode {
               onPress={handleConfigurePress}
             >
               <ThemedText style={styles.configureButtonText}>
-                Open Autofill Settings
+                {t('settings.androidAutofillSettings.openAutofillSettings')}
               </ThemedText>
             </TouchableOpacity>
             <ThemedText style={styles.tipStep}>
-              If the button above doesn&apos;t work it might be blocked because of security settings. You can manually go to Android Settings → General Management → Passwords and autofill.
+              {t('settings.androidAutofillSettings.buttonTip')}
             </ThemedText>
           </View>
           <ThemedText style={styles.instructionStep}>
-            2. Some apps, e.g. Google Chrome, may require manual configuration in their settings to allow third-party autofill apps. However, most apps should work with autofill by default.
+            {t('settings.androidAutofillSettings.step2')}
           </ThemedText>
           <View style={styles.buttonContainer}>
             {shouldShowAutofillReminder && (
@@ -166,7 +168,7 @@ export default function AndroidAutofillScreen() : React.ReactNode {
                 onPress={handleAlreadyConfigured}
               >
                 <ThemedText style={styles.secondaryButtonText}>
-                  I already configured it
+                  {t('settings.androidAutofillSettings.alreadyConfigured')}
                 </ThemedText>
               </TouchableOpacity>
             )}

--- a/apps/mobile-app/app/(tabs)/settings/android-autofill.tsx
+++ b/apps/mobile-app/app/(tabs)/settings/android-autofill.tsx
@@ -1,6 +1,6 @@
 import { router } from 'expo-router';
-import { StyleSheet, View, TouchableOpacity, Linking } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { StyleSheet, View, TouchableOpacity, Linking } from 'react-native';
 
 import { useColors } from '@/hooks/useColorScheme';
 

--- a/apps/mobile-app/app/(tabs)/settings/vault-unlock.tsx
+++ b/apps/mobile-app/app/(tabs)/settings/vault-unlock.tsx
@@ -21,7 +21,7 @@ export default function VaultUnlockSettingsScreen() : React.ReactNode {
   const { setAuthMethods, getEnabledAuthMethods, getBiometricDisplayName } = useAuth();
   const [hasBiometrics, setHasBiometrics] = useState(false);
   const [isBiometricsEnabled, setIsBiometricsEnabled] = useState(false);
-  const [biometricDisplayName, setBiometricDisplayName] = useState(Platform.OS === 'ios' ? 'Face ID / Touch ID' : 'Biometrics');
+  const [biometricDisplayName, setBiometricDisplayName] = useState(Platform.OS === 'ios' ? t('settings.vaultUnlockSettings.faceIdTouchId') : t('settings.vaultUnlockSettings.biometrics'));
   const [_, setEnabledAuthMethods] = useState<AuthMethod[]>([]);
 
   useEffect(() => {
@@ -41,7 +41,7 @@ export default function VaultUnlockSettingsScreen() : React.ReactNode {
         setHasBiometrics(isBiometricAvailable);
 
         // Get appropriate display name
-        const displayName = Platform.OS === 'ios' ? await getBiometricDisplayName() : 'Biometrics';
+        const displayName = Platform.OS === 'ios' ? await getBiometricDisplayName() : t('settings.vaultUnlockSettings.biometrics');
         setBiometricDisplayName(displayName);
 
         const methods = await getEnabledAuthMethods();
@@ -60,7 +60,7 @@ export default function VaultUnlockSettingsScreen() : React.ReactNode {
     };
 
     initializeAuth();
-  }, [getEnabledAuthMethods, getBiometricDisplayName]);
+  }, [getEnabledAuthMethods, getBiometricDisplayName, t]);
 
   useEffect(() => {
     if (!initialized) {

--- a/apps/mobile-app/app/+not-found.tsx
+++ b/apps/mobile-app/app/+not-found.tsx
@@ -1,6 +1,6 @@
 import { Link, Stack } from 'expo-router';
-import { StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { StyleSheet } from 'react-native';
 
 import { ThemedText } from '@/components/themed/ThemedText';
 import { ThemedView } from '@/components/themed/ThemedView';

--- a/apps/mobile-app/app/+not-found.tsx
+++ b/apps/mobile-app/app/+not-found.tsx
@@ -1,5 +1,6 @@
 import { Link, Stack } from 'expo-router';
 import { StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 
 import { ThemedText } from '@/components/themed/ThemedText';
 import { ThemedView } from '@/components/themed/ThemedView';
@@ -8,13 +9,15 @@ import { ThemedView } from '@/components/themed/ThemedView';
  * Not found screen.
  */
 export default function NotFoundScreen() : React.ReactNode {
+  const { t } = useTranslation();
+  
   return (
     <>
-      <Stack.Screen options={{ title: 'Oops!' }} />
+      <Stack.Screen options={{ title: t('app.notFound.title') }} />
       <ThemedView style={styles.container}>
-        <ThemedText type="title">This page doesn&apos;t exist.</ThemedText>
+        <ThemedText type="title">{t('app.notFound.message')}</ThemedText>
         <Link href="/reinitialize" style={styles.link}>
-          <ThemedText type="link">Go back to the home page</ThemedText>
+          <ThemedText type="link">{t('app.notFound.goHome')}</ThemedText>
         </Link>
       </ThemedView>
     </>

--- a/apps/mobile-app/app/login.tsx
+++ b/apps/mobile-app/app/login.tsx
@@ -522,7 +522,7 @@ export default function LoginScreen() : React.ReactNode {
           <Animated.View style={[styles.headerSection, { opacity: fadeAnim }]}>
             <View style={styles.logoContainer}>
               <Logo width={80} height={80} />
-              <Text style={styles.appName}>AliasVault</Text>
+              <Text style={styles.appName}>{t('app.appName')}</Text>
             </View>
           </Animated.View>
         </SafeAreaView>

--- a/apps/mobile-app/app/unlock.tsx
+++ b/apps/mobile-app/app/unlock.tsx
@@ -115,7 +115,7 @@ export default function UnlockScreen() : React.ReactNode {
         Alert.alert(t('common.error'), t('auth.errors.incorrectPassword'));
       }
     } catch {
-      Alert.alert('Error', 'Incorrect password. Please try again.');
+      Alert.alert(t('common.error'), t('auth.errors.incorrectPasswordFallback'));
     } finally {
       setIsLoading(false);
     }

--- a/apps/mobile-app/components/credentials/CredentialCard.tsx
+++ b/apps/mobile-app/components/credentials/CredentialCard.tsx
@@ -1,9 +1,9 @@
 import * as Clipboard from 'expo-clipboard';
 import { router } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 import { StyleSheet, View, Text, TouchableOpacity, Keyboard, Platform, Alert } from 'react-native';
 import ContextMenu, { OnPressMenuItemEvent } from 'react-native-context-menu-view';
 import Toast from 'react-native-toast-message';
-import { useTranslation } from 'react-i18next';
 
 import type { Credential } from '@/utils/dist/shared/models/vault';
 

--- a/apps/mobile-app/components/credentials/CredentialCard.tsx
+++ b/apps/mobile-app/components/credentials/CredentialCard.tsx
@@ -3,6 +3,7 @@ import { router } from 'expo-router';
 import { StyleSheet, View, Text, TouchableOpacity, Keyboard, Platform, Alert } from 'react-native';
 import ContextMenu, { OnPressMenuItemEvent } from 'react-native-context-menu-view';
 import Toast from 'react-native-toast-message';
+import { useTranslation } from 'react-i18next';
 
 import type { Credential } from '@/utils/dist/shared/models/vault';
 
@@ -20,6 +21,7 @@ type CredentialCardProps = {
  */
 export function CredentialCard({ credential, onCredentialDelete }: CredentialCardProps) : React.ReactNode {
   const colors = useColors();
+  const { t } = useTranslation();
 
   /**
    * Get the display text for a credential, showing username by default,
@@ -74,15 +76,15 @@ export function CredentialCard({ credential, onCredentialDelete }: CredentialCar
       case 'Delete':
         Keyboard.dismiss();
         Alert.alert(
-          "Delete Credential",
-          "Are you sure you want to delete this credential? This action cannot be undone.",
+          t('credentials.deleteCredential'),
+          t('credentials.deleteConfirm'),
           [
             {
-              text: "Cancel",
+              text: t('common.cancel'),
               style: "cancel"
             },
             {
-              text: "Delete",
+              text: t('common.delete'),
               style: "destructive",
               /**
                * Handles the delete credential action.
@@ -146,14 +148,14 @@ export function CredentialCard({ credential, onCredentialDelete }: CredentialCar
   }[] => {
     const actions = [
       {
-        title: 'Edit',
+        title: t('credentials.contextMenu.edit'),
         systemIcon: Platform.select({
           ios: 'pencil',
           android: 'baseline_edit',
         }),
       },
       {
-        title: 'Delete',
+        title: t('credentials.contextMenu.delete'),
         systemIcon: Platform.select({
           ios: 'trash',
           android: 'baseline_delete',
@@ -164,7 +166,7 @@ export function CredentialCard({ credential, onCredentialDelete }: CredentialCar
 
     if (credential.Username) {
       actions.push({
-        title: 'Copy Username',
+        title: t('credentials.contextMenu.copyUsername'),
         systemIcon: Platform.select({
           ios: 'person',
           android: 'baseline_person',
@@ -174,7 +176,7 @@ export function CredentialCard({ credential, onCredentialDelete }: CredentialCar
 
     if (credential.Alias?.Email) {
       actions.push({
-        title: 'Copy Email',
+        title: t('credentials.contextMenu.copyEmail'),
         systemIcon: Platform.select({
           ios: 'envelope',
           android: 'baseline_email',
@@ -184,7 +186,7 @@ export function CredentialCard({ credential, onCredentialDelete }: CredentialCar
 
     if (credential.Password) {
       actions.push({
-        title: 'Copy Password',
+        title: t('credentials.contextMenu.copyPassword'),
         systemIcon: Platform.select({
           ios: 'key',
           android: 'baseline_key',
@@ -229,7 +231,7 @@ export function CredentialCard({ credential, onCredentialDelete }: CredentialCar
 
   return (
     <ContextMenu
-      title="Credential Options"
+      title={t('credentials.contextMenu.title')}
       actions={getMenuActions()}
       onPress={handleContextMenuAction}
       previewBackgroundColor={colors.accentBackground}

--- a/apps/mobile-app/components/credentials/ServiceUrlNotice.tsx
+++ b/apps/mobile-app/components/credentials/ServiceUrlNotice.tsx
@@ -5,6 +5,7 @@ import { StyleSheet, TouchableOpacity } from 'react-native';
 import { extractServiceNameFromUrl } from '@/utils/UrlUtility';
 
 import { useColors } from '@/hooks/useColorScheme';
+import { useTranslation } from '@/hooks/useTranslation';
 
 import { ThemedText } from '@/components/themed/ThemedText';
 import { ThemedView } from '@/components/themed/ThemedView';
@@ -21,6 +22,7 @@ interface IServiceUrlNoticeProps {
 export function ServiceUrlNotice({ serviceUrl, onDismiss }: IServiceUrlNoticeProps): React.ReactNode {
   const router = useRouter();
   const colors = useColors();
+  const { t } = useTranslation();
   const serviceName = extractServiceNameFromUrl(serviceUrl);
 
   /**
@@ -65,7 +67,7 @@ export function ServiceUrlNotice({ serviceUrl, onDismiss }: IServiceUrlNoticePro
       >
         <MaterialIcons name="add-circle" size={20} color={colors.primary} />
         <ThemedText style={styles.text}>
-          Create new alias for &ldquo;{serviceName}&rdquo;?
+          {t('credentials.createNewAliasFor')} &ldquo;{serviceName}&rdquo;?
         </ThemedText>
       </TouchableOpacity>
       <TouchableOpacity

--- a/apps/mobile-app/context/AuthContext.tsx
+++ b/apps/mobile-app/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { NavigationContainerRef, ParamListBase } from '@react-navigation/native'
 import * as LocalAuthentication from 'expo-local-authentication';
 import { router, useGlobalSearchParams, usePathname } from 'expo-router';
 import React, { createContext, useContext, useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { AppState, Platform } from 'react-native';
 
 import EncryptionUtility from '@/utils/EncryptionUtility';
@@ -55,6 +56,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
  * AuthProvider to provide the authentication state to the app that components can use.
  */
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { t } = useTranslation();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const [username, setUsername] = useState<string | null>(null);
@@ -208,12 +210,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       // For Android, we use the term "Biometrics" for facial recognition and fingerprint.
       if (Platform.OS === 'android') {
-        return 'Biometrics';
+        return t('settings.vaultUnlockSettings.biometrics');
       }
 
       // For iOS, we check if the device has explicit Face ID or Touch ID support.
       if (!hasBiometrics || !enrolled) {
-        return 'Face ID / Touch ID';
+        return t('settings.vaultUnlockSettings.faceIdTouchId');
       }
 
       const types = await LocalAuthentication.supportedAuthenticationTypesAsync();
@@ -221,17 +223,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const hasTouchIDSupport = types.includes(LocalAuthentication.AuthenticationType.FINGERPRINT);
 
       if (hasFaceIDSupport) {
-        return 'Face ID';
+        return t('settings.vaultUnlockSettings.faceId');
       } else if (hasTouchIDSupport) {
-        return 'Touch ID';
+        return t('settings.vaultUnlockSettings.touchId');
       }
 
-      return 'Face ID / Touch ID';
+      return t('settings.vaultUnlockSettings.faceIdTouchId');
     } catch (error) {
       console.error('Failed to get biometric display name:', error);
-      return 'Face ID / Touch ID';
+      return t('settings.vaultUnlockSettings.faceIdTouchId');
     }
-  }, []);
+  }, [t]);
 
   /**
    * Get the display label for the current auth method
@@ -248,8 +250,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         console.error('Failed to check Face ID enrollment:', error);
       }
     }
-    return 'Password';
-  }, [getEnabledAuthMethods, getBiometricDisplayName, isBiometricsEnabledOnDevice]);
+    return t('credentials.password');
+  }, [getEnabledAuthMethods, getBiometricDisplayName, isBiometricsEnabledOnDevice, t]);
 
   /**
    * Get the auto-lock timeout from the iOS credentials manager

--- a/apps/mobile-app/i18n/locales/de.json
+++ b/apps/mobile-app/i18n/locales/de.json
@@ -43,7 +43,8 @@
       "invalidAuthCode": "Please enter a valid 6-digit authentication code",
       "incorrectPassword": "Incorrect password. Please try again.",
       "enterPassword": "Please enter your password",
-      "serverError": "Could not reach AliasVault server. Please try again later or contact support if the problem persists."
+      "serverError": "Could not reach AliasVault server. Please try again later or contact support if the problem persists.",
+      "incorrectPasswordFallback": "Incorrect password. Please try again."
     },
     "confirmLogout": "Are you sure you want to logout? You need to login again with your master password to access your vault.",
     "noAccountYet": "No account yet?",
@@ -142,7 +143,16 @@
     "errors": {
       "loadFailed": "Failed to load credential",
       "generateUsernameFailed": "Failed to generate username",
-      "generatePasswordFailed": "Failed to generate password"
+      "generatePasswordFailed": "Failed to generate password",
+      "generic": "Error"
+    },
+    "contextMenu": {
+      "title": "Credential Options",
+      "edit": "Edit",
+      "delete": "Delete",
+      "copyUsername": "Copy Username",
+      "copyEmail": "Copy Email",
+      "copyPassword": "Copy Password"
     }
   },
   "settings": {
@@ -161,6 +171,18 @@
       "warningText": "Note: You'll need to authenticate with Face ID/Touch ID or your device passcode when using autofill."
     },
     "androidAutofill": "Android Autofill",
+    "androidAutofillSettings": {
+      "warningTitle": "⚠️ Experimental Feature",
+      "warningDescription": "Autofill support for Android is currently in an experimental state.",
+      "warningLink": "Read more about it here",
+      "headerText": "You can configure AliasVault to provide native password autofill functionality in Android. Follow the instructions below to enable it.",
+      "howToEnable": "How to enable:",
+      "step1": "1. Open Android Settings via the button below, and change the \"autofill preferred service\" to \"AliasVault\"",
+      "openAutofillSettings": "Open Autofill Settings",
+      "buttonTip": "If the button above doesn't work it might be blocked because of security settings. You can manually go to Android Settings → General Management → Passwords and autofill.",
+      "step2": "2. Some apps, e.g. Google Chrome, may require manual configuration in their settings to allow third-party autofill apps. However, most apps should work with autofill by default.",
+      "alreadyConfigured": "I already configured it"
+    },
     "vaultUnlock": "Vault Unlock Method",
     "autoLock": "Auto-lock Timeout",
     "identityGenerator": "Identity Generator",
@@ -379,6 +401,12 @@
       "loginSettings": "Login Settings",
       "notFound": "Not Found"
     },
+    "notFound": {
+      "title": "Oops!",
+      "message": "This page doesn't exist.",
+      "goHome": "Go back to the home page"
+    },
+    "appName": "AliasVault",
     "reinitialize": {
       "vaultAutoLockedMessage": "Vault auto-locked after timeout.",
       "attemptingToUnlockMessage": "Attempting to unlock."

--- a/apps/mobile-app/i18n/locales/en.json
+++ b/apps/mobile-app/i18n/locales/en.json
@@ -205,6 +205,10 @@
     "openSettings": "Open Settings",
     "vaultUnlockSettings": {
       "description": "Choose how you want to unlock your vault.",
+      "biometrics": "Biometrics",
+      "faceId": "Face ID",
+      "touchId": "Touch ID",
+      "faceIdTouchId": "Face ID / Touch ID",
       "biometricEnabled": "{{biometric}} is now successfully enabled",
       "biometricNotAvailable": "{{biometric}} Not Available",
       "biometricDisabledMessage": "{{biometric}} is disabled for AliasVault. In order to use it, please enable it in your device settings first.",

--- a/apps/mobile-app/i18n/locales/en.json
+++ b/apps/mobile-app/i18n/locales/en.json
@@ -43,7 +43,8 @@
       "invalidAuthCode": "Please enter a valid 6-digit authentication code",
       "incorrectPassword": "Incorrect password. Please try again.",
       "enterPassword": "Please enter your password",
-      "serverError": "Could not reach AliasVault server. Please try again later or contact support if the problem persists."
+      "serverError": "Could not reach AliasVault server. Please try again later or contact support if the problem persists.",
+      "incorrectPasswordFallback": "Incorrect password. Please try again."
     },
     "confirmLogout": "Are you sure you want to logout? You need to login again with your master password to access your vault.",
     "noAccountYet": "No account yet?",
@@ -139,10 +140,20 @@
       "credentialUpdated": "Credential updated successfully",
       "credentialCreated": "Credential created successfully"
     },
+    "createNewAliasFor": "Create new alias for",
     "errors": {
       "loadFailed": "Failed to load credential",
       "generateUsernameFailed": "Failed to generate username",
-      "generatePasswordFailed": "Failed to generate password"
+      "generatePasswordFailed": "Failed to generate password",
+      "generic": "Error"
+    },
+    "contextMenu": {
+      "title": "Credential Options",
+      "edit": "Edit",
+      "delete": "Delete",
+      "copyUsername": "Copy Username",
+      "copyEmail": "Copy Email",
+      "copyPassword": "Copy Password"
     }
   },
   "settings": {
@@ -161,6 +172,18 @@
       "warningText": "Note: You'll need to authenticate with Face ID/Touch ID or your device passcode when using autofill."
     },
     "androidAutofill": "Android Autofill",
+    "androidAutofillSettings": {
+      "warningTitle": "⚠️ Experimental Feature",
+      "warningDescription": "Autofill support for Android is currently in an experimental state.",
+      "warningLink": "Read more about it here",
+      "headerText": "You can configure AliasVault to provide native password autofill functionality in Android. Follow the instructions below to enable it.",
+      "howToEnable": "How to enable:",
+      "step1": "1. Open Android Settings via the button below, and change the \"autofill preferred service\" to \"AliasVault\"",
+      "openAutofillSettings": "Open Autofill Settings",
+      "buttonTip": "If the button above doesn't work it might be blocked because of security settings. You can manually go to Android Settings → General Management → Passwords and autofill.",
+      "step2": "2. Some apps, e.g. Google Chrome, may require manual configuration in their settings to allow third-party autofill apps. However, most apps should work with autofill by default.",
+      "alreadyConfigured": "I already configured it"
+    },
     "vaultUnlock": "Vault Unlock Method",
     "autoLock": "Auto-lock Timeout",
     "identityGenerator": "Identity Generator",
@@ -379,6 +402,12 @@
       "loginSettings": "Login Settings",
       "notFound": "Not Found"
     },
+    "notFound": {
+      "title": "Page not found",
+      "message": "This page has been moved or deleted.",
+      "goHome": "Go back to the start"
+    },
+    "appName": "AliasVault",
     "reinitialize": {
       "vaultAutoLockedMessage": "Vault auto-locked after timeout.",
       "attemptingToUnlockMessage": "Attempting to unlock."

--- a/apps/mobile-app/i18n/locales/es.json
+++ b/apps/mobile-app/i18n/locales/es.json
@@ -43,7 +43,8 @@
       "invalidAuthCode": "Please enter a valid 6-digit authentication code",
       "incorrectPassword": "Incorrect password. Please try again.",
       "enterPassword": "Please enter your password",
-      "serverError": "Could not reach AliasVault server. Please try again later or contact support if the problem persists."
+      "serverError": "Could not reach AliasVault server. Please try again later or contact support if the problem persists.",
+      "incorrectPasswordFallback": "Incorrect password. Please try again."
     },
     "confirmLogout": "Are you sure you want to logout? You need to login again with your master password to access your vault.",
     "noAccountYet": "No account yet?",
@@ -142,7 +143,16 @@
     "errors": {
       "loadFailed": "Failed to load credential",
       "generateUsernameFailed": "Failed to generate username",
-      "generatePasswordFailed": "Failed to generate password"
+      "generatePasswordFailed": "Failed to generate password",
+      "generic": "Error"
+    },
+    "contextMenu": {
+      "title": "Credential Options",
+      "edit": "Edit",
+      "delete": "Delete",
+      "copyUsername": "Copy Username",
+      "copyEmail": "Copy Email",
+      "copyPassword": "Copy Password"
     }
   },
   "settings": {
@@ -161,6 +171,18 @@
       "warningText": "Note: You'll need to authenticate with Face ID/Touch ID or your device passcode when using autofill."
     },
     "androidAutofill": "Android Autofill",
+    "androidAutofillSettings": {
+      "warningTitle": "⚠️ Experimental Feature",
+      "warningDescription": "Autofill support for Android is currently in an experimental state.",
+      "warningLink": "Read more about it here",
+      "headerText": "You can configure AliasVault to provide native password autofill functionality in Android. Follow the instructions below to enable it.",
+      "howToEnable": "How to enable:",
+      "step1": "1. Open Android Settings via the button below, and change the \"autofill preferred service\" to \"AliasVault\"",
+      "openAutofillSettings": "Open Autofill Settings",
+      "buttonTip": "If the button above doesn't work it might be blocked because of security settings. You can manually go to Android Settings → General Management → Passwords and autofill.",
+      "step2": "2. Some apps, e.g. Google Chrome, may require manual configuration in their settings to allow third-party autofill apps. However, most apps should work with autofill by default.",
+      "alreadyConfigured": "I already configured it"
+    },
     "vaultUnlock": "Vault Unlock Method",
     "autoLock": "Auto-lock Timeout",
     "identityGenerator": "Identity Generator",
@@ -379,6 +401,12 @@
       "loginSettings": "Login Settings",
       "notFound": "Not Found"
     },
+    "notFound": {
+      "title": "Page not found",
+      "message": "This page has been moved or deleted.",
+      "goHome": "Go back to the start"
+    },
+    "appName": "AliasVault",
     "reinitialize": {
       "vaultAutoLockedMessage": "Vault auto-locked after timeout.",
       "attemptingToUnlockMessage": "Attempting to unlock."

--- a/apps/mobile-app/i18n/locales/fr.json
+++ b/apps/mobile-app/i18n/locales/fr.json
@@ -43,7 +43,8 @@
       "invalidAuthCode": "Please enter a valid 6-digit authentication code",
       "incorrectPassword": "Mot de passe incorrect. Veuillez réessayer.",
       "enterPassword": "Please enter your password",
-      "serverError": "Could not reach AliasVault server. Please try again later or contact support if the problem persists."
+      "serverError": "Could not reach AliasVault server. Please try again later or contact support if the problem persists.",
+      "incorrectPasswordFallback": "Incorrect password. Please try again."
     },
     "confirmLogout": "Are you sure you want to logout? You need to login again with your master password to access your vault.",
     "noAccountYet": "Pas encore de compte ?",
@@ -142,7 +143,16 @@
     "errors": {
       "loadFailed": "Failed to load credential",
       "generateUsernameFailed": "Failed to generate username",
-      "generatePasswordFailed": "Failed to generate password"
+      "generatePasswordFailed": "Failed to generate password",
+      "generic": "Error"
+    },
+    "contextMenu": {
+      "title": "Credential Options",
+      "edit": "Edit",
+      "delete": "Delete",
+      "copyUsername": "Copy Username",
+      "copyEmail": "Copy Email",
+      "copyPassword": "Copy Password"
     }
   },
   "settings": {
@@ -161,6 +171,18 @@
       "warningText": "Note : Vous devrez vous authentifier avec Face ID/Touch ID ou votre code d'accès lorsque vous utilisez le remplissage automatique."
     },
     "androidAutofill": "Remplissage automatique Android",
+    "androidAutofillSettings": {
+      "warningTitle": "⚠️ Experimental Feature",
+      "warningDescription": "Autofill support for Android is currently in an experimental state.",
+      "warningLink": "Read more about it here",
+      "headerText": "You can configure AliasVault to provide native password autofill functionality in Android. Follow the instructions below to enable it.",
+      "howToEnable": "How to enable:",
+      "step1": "1. Open Android Settings via the button below, and change the \"autofill preferred service\" to \"AliasVault\"",
+      "openAutofillSettings": "Open Autofill Settings",
+      "buttonTip": "If the button above doesn't work it might be blocked because of security settings. You can manually go to Android Settings → General Management → Passwords and autofill.",
+      "step2": "2. Some apps, e.g. Google Chrome, may require manual configuration in their settings to allow third-party autofill apps. However, most apps should work with autofill by default.",
+      "alreadyConfigured": "I already configured it"
+    },
     "vaultUnlock": "Méthode de déverrouillage du coffre-fort",
     "autoLock": "Délai de verrouillage automatique",
     "identityGenerator": "Générateur d'identité",
@@ -379,6 +401,12 @@
       "loginSettings": "Login Settings",
       "notFound": "Not Found"
     },
+    "notFound": {
+      "title": "Page not found",
+      "message": "This page has been moved or deleted.",
+      "goHome": "Go back to the start"
+    },
+    "appName": "AliasVault",
     "reinitialize": {
       "vaultAutoLockedMessage": "Vault auto-locked after timeout.",
       "attemptingToUnlockMessage": "Attempting to unlock."

--- a/apps/mobile-app/i18n/locales/nl.json
+++ b/apps/mobile-app/i18n/locales/nl.json
@@ -43,7 +43,8 @@
       "invalidAuthCode": "Voer een geldige 6-cijferige authenticatiecode in",
       "incorrectPassword": "Onjuist wachtwoord. Probeer het opnieuw.",
       "enterPassword": "Voer je wachtwoord in",
-      "serverError": "Kon de AliasVault server niet bereiken. Probeer het later opnieuw of neem contact op met support als het probleem aanhoudt."
+      "serverError": "Kon de AliasVault server niet bereiken. Probeer het later opnieuw of neem contact op met support als het probleem aanhoudt.",
+      "incorrectPasswordFallback": "Incorrect password. Please try again."
     },
     "confirmLogout": "Weet je zeker dat je wilt uitloggen? Je moet opnieuw inloggen met je hoofdwachtwoord om toegang te krijgen tot je vault.",
     "noAccountYet": "Nog geen account?",
@@ -142,7 +143,16 @@
     "errors": {
       "loadFailed": "Laden van credential mislukt",
       "generateUsernameFailed": "Genereren van gebruikersnaam mislukt",
-      "generatePasswordFailed": "Genereren van wachtwoord mislukt"
+      "generatePasswordFailed": "Genereren van wachtwoord mislukt",
+      "generic": "Error"
+    },
+    "contextMenu": {
+      "title": "Credential Options",
+      "edit": "Edit",
+      "delete": "Delete",
+      "copyUsername": "Copy Username",
+      "copyEmail": "Copy Email",
+      "copyPassword": "Copy Password"
     }
   },
   "settings": {
@@ -161,6 +171,18 @@
       "warningText": "Let op: Face ID/Touch ID of je toegangscode is vereist bij het gebruik van autofill."
     },
     "androidAutofill": "Android autofill",
+    "androidAutofillSettings": {
+      "warningTitle": "⚠️ Experimental Feature",
+      "warningDescription": "Autofill support for Android is currently in an experimental state.",
+      "warningLink": "Read more about it here",
+      "headerText": "You can configure AliasVault to provide native password autofill functionality in Android. Follow the instructions below to enable it.",
+      "howToEnable": "How to enable:",
+      "step1": "1. Open Android Settings via the button below, and change the \"autofill preferred service\" to \"AliasVault\"",
+      "openAutofillSettings": "Open Autofill Settings",
+      "buttonTip": "If the button above doesn't work it might be blocked because of security settings. You can manually go to Android Settings → General Management → Passwords and autofill.",
+      "step2": "2. Some apps, e.g. Google Chrome, may require manual configuration in their settings to allow third-party autofill apps. However, most apps should work with autofill by default.",
+      "alreadyConfigured": "I already configured it"
+    },
     "vaultUnlock": "Vault ontgrendelmethode",
     "autoLock": "Automatisch vergrendelen",
     "identityGenerator": "Identiteit generator",
@@ -379,6 +401,12 @@
       "loginSettings": "Login instellingen",
       "notFound": "Niet gevonden"
     },
+    "notFound": {
+      "title": "Page not found",
+      "message": "This page has been moved or deleted.",
+      "goHome": "Go back to the start"
+    },
+    "appName": "AliasVault",
     "reinitialize": {
       "vaultAutoLockedMessage": "Vault automatisch vergrendeld na time-out.",
       "attemptingToUnlockMessage": "Bezig met ontgrendelen."

--- a/apps/mobile-app/i18n/locales/uk.json
+++ b/apps/mobile-app/i18n/locales/uk.json
@@ -43,7 +43,8 @@
       "invalidAuthCode": "Please enter a valid 6-digit authentication code",
       "incorrectPassword": "Incorrect password. Please try again.",
       "enterPassword": "Please enter your password",
-      "serverError": "Could not reach AliasVault server. Please try again later or contact support if the problem persists."
+      "serverError": "Could not reach AliasVault server. Please try again later or contact support if the problem persists.",
+      "incorrectPasswordFallback": "Incorrect password. Please try again."
     },
     "confirmLogout": "Are you sure you want to logout? You need to login again with your master password to access your vault.",
     "noAccountYet": "No account yet?",
@@ -142,7 +143,16 @@
     "errors": {
       "loadFailed": "Failed to load credential",
       "generateUsernameFailed": "Failed to generate username",
-      "generatePasswordFailed": "Failed to generate password"
+      "generatePasswordFailed": "Failed to generate password",
+      "generic": "Error"
+    },
+    "contextMenu": {
+      "title": "Credential Options",
+      "edit": "Edit",
+      "delete": "Delete",
+      "copyUsername": "Copy Username",
+      "copyEmail": "Copy Email",
+      "copyPassword": "Copy Password"
     }
   },
   "settings": {
@@ -161,6 +171,18 @@
       "warningText": "Note: You'll need to authenticate with Face ID/Touch ID or your device passcode when using autofill."
     },
     "androidAutofill": "Android Autofill",
+    "androidAutofillSettings": {
+      "warningTitle": "⚠️ Experimental Feature",
+      "warningDescription": "Autofill support for Android is currently in an experimental state.",
+      "warningLink": "Read more about it here",
+      "headerText": "You can configure AliasVault to provide native password autofill functionality in Android. Follow the instructions below to enable it.",
+      "howToEnable": "How to enable:",
+      "step1": "1. Open Android Settings via the button below, and change the \"autofill preferred service\" to \"AliasVault\"",
+      "openAutofillSettings": "Open Autofill Settings",
+      "buttonTip": "If the button above doesn't work it might be blocked because of security settings. You can manually go to Android Settings → General Management → Passwords and autofill.",
+      "step2": "2. Some apps, e.g. Google Chrome, may require manual configuration in their settings to allow third-party autofill apps. However, most apps should work with autofill by default.",
+      "alreadyConfigured": "I already configured it"
+    },
     "vaultUnlock": "Vault Unlock Method",
     "autoLock": "Auto-lock Timeout",
     "identityGenerator": "Identity Generator",
@@ -379,6 +401,12 @@
       "loginSettings": "Login Settings",
       "notFound": "Not Found"
     },
+    "notFound": {
+      "title": "Page not found",
+      "message": "This page has been moved or deleted.",
+      "goHome": "Go back to the start"
+    },
+    "appName": "AliasVault",
     "reinitialize": {
       "vaultAutoLockedMessage": "Vault auto-locked after timeout.",
       "attemptingToUnlockMessage": "Attempting to unlock."


### PR DESCRIPTION
## Description
- [x] Bug fix

Adds missing translation sources for:
- Android autofill settings page
- Login/unlock screen components
- Credential long-press context menu
- Create new alias notice
- Android biometrics unlock native component
- Vault unlock method name (biometrics, faceid/touchid etc)

## Related Issues
Fixes #1085 

## Checklist
- [x] Code adheres to project standards and guidelines.
- [x] Documentation has been updated where applicable.
