### PR TITLE
Enable "save login to aliasvault" prompt in browser extension by default

### DIFF
--- a/apps/browser-extension/src/utils/LocalPreferencesService.ts
+++ b/apps/browser-extension/src/utils/LocalPreferencesService.ts
@@ -362,11 +362,11 @@ export const LocalPreferencesService = {
 
   /**
    * Get whether the login save feature is enabled.
-   * @returns Whether login save is enabled. Defaults to false (disabled by default).
+   * @returns Whether login save is enabled. Defaults to true (enabled by default).
    */
   async getLoginSaveEnabled(): Promise<boolean> {
     const value = await storage.getItem(KEYS.LOGIN_SAVE_ENABLED) as boolean | null;
-    return value === true;
+    return value !== false;
   },
 
   /**


### PR DESCRIPTION
## Description
- [x] Feature enhancement

## Related Issues
- #1784

## Checklist
- [x] Code adheres to project standards and guidelines.
- [x] Documentation has been updated where applicable.

