### PR TITLE
fix: guard against undefined credentials.create/get in WebAuthn override

### DIFF
--- a/apps/browser-extension/src/entrypoints/webauthn.ts
+++ b/apps/browser-extension/src/entrypoints/webauthn.ts
@@ -27,7 +27,7 @@ export default defineUnlistedScript(() => {
    * Check if navigator.credentials API is available
    * Some pages (iframes, non-secure contexts, older browsers) may not have this API
    */
-  if (!navigator.credentials) {
+  if (!navigator.credentials || !navigator.credentials.create || !navigator.credentials.get) {
     return;
   }
 


### PR DESCRIPTION
## Bug
[#1854](https://github.com/aliasvault/aliasvault/issues/1854) — Opening certain websites (e.g. VNC viewers) with the AliasVault extension enabled crashes with `Cannot read properties of undefined (reading 'create')`.

## Fix
Extended the `navigator.credentials` availability check to also verify that `create` and `get` methods exist before attempting to `.bind()` them. Some browser contexts (iframes with restricted permissions, certain embedded pages) expose a partial `CredentialsContainer` where the object itself exists but individual methods are undefined.

The existing guard only checked `!navigator.credentials`, which passed for these partial implementations. The script then crashed on `navigator.credentials.create.bind(...)` since `create` was `undefined`.

## Testing
Verified the guard exits early when either method is missing, preventing the TypeError. Normal WebAuthn functionality is unaffected since the guard only fires when the API is incomplete.

Happy to address any feedback.

Greetings, saschabuehrle