### PR TITLE
feat(email): add html/plain/source view mode dropdown to email modal (closes #150)

### DIFF
--- a/apps/server/AliasVault.Api/Controllers/Email/EmailController.cs
+++ b/apps/server/AliasVault.Api/Controllers/Email/EmailController.cs
@@ -54,6 +54,7 @@ public class EmailController(ILogger<VaultController> logger, IAliasServerDbCont
             SecondsAgo = (int)DateTime.UtcNow.Subtract(email.DateSystem).TotalSeconds,
             MessageHtml = email.MessageHtml,
             MessagePlain = email.MessagePlain,
+            MessageSource = email.MessageSource,
             EncryptedSymmetricKey = email.EncryptedSymmetricKey,
             EncryptionKey = email.EncryptionKey.PublicKey,
         };

--- a/apps/server/AliasVault.Client/Main/Components/Email/EmailModal.razor
+++ b/apps/server/AliasVault.Client/Main/Components/Email/EmailModal.razor
@@ -45,15 +45,38 @@
                         <p>@Localizer["ActionsLabel"] <button @onclick="ShowDeleteConfirmation" class="text-red-500 hover:text-red-700 text-sm">@Localizer["DeleteButton"]</button></p>
                     </div>
                 </div>
+                @if (AvailableViewModes.Count > 1)
+                {
+                    <div class="mt-3 flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                        <label for="email-view-mode" class="shrink-0">@Localizer["ViewModeLabel"]</label>
+                        <select id="email-view-mode"
+                                @onchange="OnViewModeChanged"
+                                value="@CurrentViewMode.ToString()"
+                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block p-1 dark:bg-gray-700 dark:border-gray-600 dark:text-white">
+                            @foreach (var mode in AvailableViewModes)
+                            {
+                                <option value="@mode.ToString()">@Localizer[ViewModeLocalizationKey(mode)]</option>
+                            }
+                        </select>
+                    </div>
+                }
             </div>
 
             <!-- Scrollable Content -->
             <div class="flex-1 overflow-y-auto p-4">
                 <div class="text-gray-700 dark:text-gray-300">
-                    <div>
-                        <iframe class="w-full overscroll-y-auto" style="height:500px;" srcdoc="@EmailBody" sandbox="allow-popups allow-popups-to-escape-sandbox">
-                        </iframe>
-                    </div>
+                    @if (CurrentViewMode == EmailViewMode.Source)
+                    {
+                        <pre class="w-full overflow-auto text-xs p-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded whitespace-pre-wrap break-words"
+                             style="max-height:500px;">@EmailBody</pre>
+                    }
+                    else
+                    {
+                        <div>
+                            <iframe class="w-full overscroll-y-auto" style="height:500px;" srcdoc="@EmailBody" sandbox="allow-popups allow-popups-to-escape-sandbox">
+                            </iframe>
+                        </div>
+                    }
                 </div>
                 <div class="mt-4">
                     @if (Email?.Attachments?.Any() == true)
@@ -115,9 +138,35 @@
     public EventCallback<int> OnEmailDeleted { get; set; }
 
     /// <summary>
-    /// The message body to display
+    /// The message body to display (already rendered for the <see cref="CurrentViewMode"/>).
     /// </summary>
     private string EmailBody = string.Empty;
+
+    /// <summary>
+    /// Supported email body view modes.
+    /// </summary>
+    private enum EmailViewMode
+    {
+        /// <summary>Rendered HTML body (sanitized) in an iframe.</summary>
+        Html,
+
+        /// <summary>Plain text body, rendered in a preformatted block.</summary>
+        Plain,
+
+        /// <summary>Raw RFC 822 / MIME source, rendered in a preformatted block.</summary>
+        Source,
+    }
+
+    /// <summary>
+    /// The view modes the current email actually has content for,
+    /// in stable display order (HTML, Plain, Source).
+    /// </summary>
+    private List<EmailViewMode> AvailableViewModes { get; set; } = new();
+
+    /// <summary>
+    /// The view mode currently rendered in the modal body.
+    /// </summary>
+    private EmailViewMode CurrentViewMode { get; set; } = EmailViewMode.Html;
 
     /// <summary>
     /// Show confirmation modal before deleting email.
@@ -242,29 +291,92 @@
     {
         await base.OnInitializedAsync();
 
-        // Determine email body
-        if (Email != null)
+        if (Email == null)
         {
-            // Check if there is HTML content, if not, then set default viewtype to plain
-            if (Email.MessageHtml is not null && !string.IsNullOrWhiteSpace(Email.MessageHtml))
-            {
-                // HTML is available, sanitize and prepare for display
-                EmailBody = ConversionUtility.SanitizeAndPrepareEmailHtml(Email.MessageHtml);
-            }
-            else if (Email.MessagePlain is not null)
-            {
-                // No HTML but plain text is available
-                // Escape HTML entities and wrap in pre tag to preserve formatting
+            return;
+        }
+
+        // Figure out which view modes this email has content for, in a stable order.
+        AvailableViewModes.Clear();
+        if (!string.IsNullOrWhiteSpace(Email.MessageHtml))
+        {
+            AvailableViewModes.Add(EmailViewMode.Html);
+        }
+
+        if (!string.IsNullOrEmpty(Email.MessagePlain))
+        {
+            AvailableViewModes.Add(EmailViewMode.Plain);
+        }
+
+        if (!string.IsNullOrEmpty(Email.MessageSource))
+        {
+            AvailableViewModes.Add(EmailViewMode.Source);
+        }
+
+        // Default to the richest available view, matching legacy behaviour
+        // (HTML if present, otherwise plain text, otherwise raw source).
+        CurrentViewMode = AvailableViewModes.FirstOrDefault();
+        RenderEmailBody();
+    }
+
+    /// <summary>
+    /// Rebuild <see cref="EmailBody"/> for the current <see cref="CurrentViewMode"/>.
+    /// </summary>
+    private void RenderEmailBody()
+    {
+        if (Email == null || AvailableViewModes.Count == 0)
+        {
+            EmailBody = Localizer["NoEmailBody"];
+            return;
+        }
+
+        switch (CurrentViewMode)
+        {
+            case EmailViewMode.Html when !string.IsNullOrWhiteSpace(Email.MessageHtml):
+                EmailBody = ConversionUtility.SanitizeAndPrepareEmailHtml(Email.MessageHtml!);
+                break;
+
+            case EmailViewMode.Plain when !string.IsNullOrEmpty(Email.MessagePlain):
                 var escapedText = System.Net.WebUtility.HtmlEncode(Email.MessagePlain);
                 EmailBody = $"<pre style='font-family: system-ui, -apple-system, sans-serif; white-space: pre-wrap; word-wrap: break-word; margin: 0;'>{escapedText}</pre>";
-            }
-            else
-            {
-                // No HTML and no plain text available
+                break;
+
+            case EmailViewMode.Source when !string.IsNullOrEmpty(Email.MessageSource):
+                // Render as-is in a <pre>; HTML-encoding is handled by Blazor's
+                // implicit expression escaping where the pre is bound to
+                // @EmailBody in the markup.
+                EmailBody = Email.MessageSource!;
+                break;
+
+            default:
                 EmailBody = Localizer["NoEmailBody"];
-            }
+                break;
         }
     }
+
+    /// <summary>
+    /// Handle a change on the view-mode <c>&lt;select&gt;</c>.
+    /// </summary>
+    private void OnViewModeChanged(ChangeEventArgs args)
+    {
+        if (args.Value is string raw && Enum.TryParse<EmailViewMode>(raw, ignoreCase: true, out var parsed)
+            && AvailableViewModes.Contains(parsed))
+        {
+            CurrentViewMode = parsed;
+            RenderEmailBody();
+        }
+    }
+
+    /// <summary>
+    /// Localization key for a given view mode's dropdown label.
+    /// </summary>
+    private static string ViewModeLocalizationKey(EmailViewMode mode) => mode switch
+    {
+        EmailViewMode.Html => "ViewModeHtml",
+        EmailViewMode.Plain => "ViewModeText",
+        EmailViewMode.Source => "ViewModeSource",
+        _ => "ViewModeHtml",
+    };
 
     /// <summary>
     /// Download an attachment.

--- a/apps/server/AliasVault.Client/Resources/Components/Main/Email/EmailModal.en.resx
+++ b/apps/server/AliasVault.Client/Resources/Components/Main/Email/EmailModal.en.resx
@@ -118,4 +118,20 @@
     <value>Error downloading attachment</value>
     <comment>Error message for attachment download error</comment>
   </data>
+  <data name="ViewModeLabel" xml:space="preserve">
+    <value>View:</value>
+    <comment>Label for the email body view mode selector (HTML / Text / Source)</comment>
+  </data>
+  <data name="ViewModeHtml" xml:space="preserve">
+    <value>HTML</value>
+    <comment>Email body view mode option: rendered HTML</comment>
+  </data>
+  <data name="ViewModeText" xml:space="preserve">
+    <value>Text</value>
+    <comment>Email body view mode option: plain text</comment>
+  </data>
+  <data name="ViewModeSource" xml:space="preserve">
+    <value>Source</value>
+    <comment>Email body view mode option: raw MIME source</comment>
+  </data>
 </root>

--- a/apps/server/AliasVault.Client/Services/EmailService.cs
+++ b/apps/server/AliasVault.Client/Services/EmailService.cs
@@ -145,6 +145,11 @@ public sealed class EmailService(DbService dbService, JsInteropService jsInterop
                 email.MessagePlain = await jsInteropService.SymmetricDecrypt(email.MessagePlain, decryptedSymmetricKeyBase64);
             }
 
+            if (email.MessageSource is not null)
+            {
+                email.MessageSource = await jsInteropService.SymmetricDecrypt(email.MessageSource, decryptedSymmetricKeyBase64);
+            }
+
             email.FromDisplay = await jsInteropService.SymmetricDecrypt(email.FromDisplay, decryptedSymmetricKeyBase64);
             email.FromLocal = await jsInteropService.SymmetricDecrypt(email.FromLocal, decryptedSymmetricKeyBase64);
             email.FromDomain = await jsInteropService.SymmetricDecrypt(email.FromDomain, decryptedSymmetricKeyBase64);

--- a/apps/server/Shared/AliasVault.Shared/Models/Spamok/EmailApiModel.cs
+++ b/apps/server/Shared/AliasVault.Shared/Models/Spamok/EmailApiModel.cs
@@ -25,6 +25,11 @@ public class EmailApiModel : EmailApiModelBase
     public string? MessagePlain { get; set; }
 
     /// <summary>
+    /// Gets or sets the raw source (RFC 822 / MIME) of the email message.
+    /// </summary>
+    public string? MessageSource { get; set; }
+
+    /// <summary>
     /// Gets or sets the list of attachments in the email.
     /// </summary>
     public List<AttachmentApiModel> Attachments { get; set; } = [];


### PR DESCRIPTION
Closes #150.

## What

Adds an **HTML / Text / Source** view-mode dropdown to the email modal so users can switch between the email body representations their email actually contains. The raw MIME source is already stored and encrypted server-side — it just wasn't exposed through the API.

## Why

Currently the modal silently picks one representation (HTML if present, otherwise plain text). If the HTML renders poorly, if you want to inspect headers, or if you're debugging how an alias received an email, there's no way to get at the other formats — even though the server has them.

## Changes

| File | Change |
| ---- | ------ |
| `Shared/AliasVault.Shared/Models/Spamok/EmailApiModel.cs` | New `MessageSource` property. |
| `AliasVault.Api/Controllers/Email/EmailController.cs` | Populate `MessageSource = email.MessageSource` in `GetEmail`. |
| `AliasVault.Client/Services/EmailService.cs` | Decrypt `MessageSource` in `DecryptSingleEmail` with the same symmetric key path used for html/plain. |
| `AliasVault.Client/Main/Components/Email/EmailModal.razor` | Add an `EmailViewMode` enum, compute the list of modes the email actually has content for, render a `<select>` in the header when ≥2 modes exist, render the body accordingly. |
| `AliasVault.Client/Resources/Components/Main/Email/EmailModal.en.resx` | Add `ViewModeLabel`, `ViewModeHtml`, `ViewModeText`, `ViewModeSource`. |

## Behaviour & safety notes

- **Default selection preserves the old fallback order**: `HTML > Plain > Source`. Existing emails render exactly as they did before; the dropdown only appears when more than one representation is available.
- **Encryption path is symmetrical**. `EmailEncryption.cs` already symmetrically encrypts `MessageSource` on write alongside `MessageHtml`/`MessagePlain`. The API now returns it still encrypted, and `EmailService.DecryptSingleEmail` decrypts it with the same key that already handles the other two fields. No change to keys, crypto, or the wire format of anything else.
- **HTML/Plain still render in the sandboxed iframe** via `srcdoc` (unchanged). **Source renders in a `<pre>`** bound to an implicit Razor expression, so Blazor HTML-escapes the raw MIME for us — no chance of raw headers or a `<script>` payload in the source leaking into the page DOM.
- **`MessagePlain` empty-string handling** was tightened slightly: the previous code treated `""` as "plain is available" and rendered an empty `<pre>`. The new code uses `!string.IsNullOrEmpty` for both plain and source, which seems closer to the intent and matches how `MessageHtml` already behaved (`IsNullOrWhiteSpace`). Happy to revert that nuance if it's load-bearing somewhere.

## Localization

English strings added to `EmailModal.en.resx`. Per `CONTRIBUTING.md` the other languages are handled through Crowdin, so this PR doesn't touch the translated resx files.

## Testing

- `dotnet build AliasVault.Client/AliasVault.Client.csproj` — clean (0 errors, only pre-existing `WASM0001` / `sqlite3` warnings unrelated to this change).
- `dotnet build AliasVault.Api/AliasVault.Api.csproj` — clean.
- `dotnet build Shared/AliasVault.Shared/AliasVault.Shared.csproj` — clean.
- Manually walked through the three rendering paths and the dropdown enable-logic for `{html only}`, `{html + plain}`, `{plain + source}`, `{html + plain + source}`, and `{nothing}`.

## Out of scope

- Mobile app (`apps/mobile-app/`) has its own email modal; this PR only touches the web client. Happy to follow up in a separate PR if you'd like the same switcher there.